### PR TITLE
Link to the PQ example in wolfssl-examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # wolfSSL Examples for STM32
 
 * [STM32H743_Nucleo_ETH](STM32H743_Nucleo_ETH): wolfSSL TLS with TPM example
+* [STM32F446ZE_Nucleo_PQ](STM32F446ZE_Nucleo_PQ): wolfSSL Post-Quantum example, this is a pointer to another repository

--- a/STM32F446ZE_Nucleo_PQ/README.md
+++ b/STM32F446ZE_Nucleo_PQ/README.md
@@ -1,0 +1,5 @@
+# STM32F446ZE Nucelo Post Quantum Example
+
+There is example code available in the `/pq/tls/stm32` directory of our
+[wolfssl-examples repository](https://github.com/wolfSSL/wolfssl-examples/tree/master/pq/tls/stm32).
+


### PR DESCRIPTION
This example appears to be tied to the certs and the PC-side parts of the example in the `wolfssl-examples` repository. This is a link to that for now.