### PR TITLE
STM32_Bare_Test: SRAM PUF regression target

### DIFF
--- a/STM32_Bare_Test/Makefile
+++ b/STM32_Bare_Test/Makefile
@@ -53,8 +53,8 @@ endif
 ifeq ($(filter $(CONFIG),c asm bare),)
   $(error CONFIG must be one of: c | asm | bare)
 endif
-ifeq ($(filter $(TARGET),test bench dhuk stsaes ccb ccbhal c5rng c5sign cbonly),)
-  $(error TARGET must be one of: test | bench | dhuk | stsaes | ccb | ccbhal | c5rng | c5sign | cbonly)
+ifeq ($(filter $(TARGET),test bench dhuk stsaes ccb ccbhal c5rng c5sign cbonly puf),)
+  $(error TARGET must be one of: test | bench | dhuk | stsaes | ccb | ccbhal | c5rng | c5sign | cbonly | puf)
 endif
 # c5rng: bare register-level STM32C5 HW-RNG conditioning probe (no wolfCrypt).
 # c5sign: bare STM32C5 PROTECTED ECDSA-sign probe driving ST's NIST P-256 CAVP
@@ -238,7 +238,29 @@ else
   GCM_DEFS :=
 endif
 
-COMMON_DEFS := -DWOLFSSL_USER_SETTINGS $(CPU_DEFS) $(VARIANT_DEFS) $(BUILD_DEFS) $(PQC_DEFS) $(STACK_DEFS) $(GCM_DEFS)
+# PUF axis: TARGET=puf builds the SRAM PUF regression (src/main_puf.c),
+# gating WOLFSSL_PUF + WOLFSSL_PUF_TEST in user_settings.h. PUF_T selects
+# the BCH profile (7|10|13|15); PUF_CW selects WC_PUF_NUM_CODEWORDS.
+ifeq ($(TARGET),puf)
+  PUF_DEFS := -DSTM32_BARE_PUF
+  ifneq ($(PUF_T),)
+    ifeq ($(filter $(PUF_T),7 10 13 15),)
+      $(error PUF_T must be one of 7, 10, 13, 15)
+    endif
+    PUF_DEFS += -DWC_PUF_BCH_T=$(PUF_T)
+  endif
+  ifneq ($(PUF_CW),)
+    PUF_DEFS += -DWC_PUF_NUM_CODEWORDS=$(PUF_CW)
+  endif
+  # PUF_COMPACT=1 selects the opt-in parity-only helper layout.
+  ifeq ($(PUF_COMPACT),1)
+    PUF_DEFS += -DWC_PUF_HELPER_COMPACT
+  endif
+else
+  PUF_DEFS :=
+endif
+
+COMMON_DEFS := -DWOLFSSL_USER_SETTINGS $(CPU_DEFS) $(VARIANT_DEFS) $(BUILD_DEFS) $(PQC_DEFS) $(STACK_DEFS) $(GCM_DEFS) $(PUF_DEFS)
 
 CFLAGS    = $(MCU_FLAGS) $(INCLUDES) $(COMMON_DEFS) \
             -O2 -fomit-frame-pointer \

--- a/STM32_Bare_Test/README.md
+++ b/STM32_Bare_Test/README.md
@@ -179,6 +179,7 @@ has nothing to accelerate.
 | `ccb`  | `src/main_ccb.c`  | Transparent CCB-protected ECDSA (P-256) via `wc_ecc_sign_hash` -- bare + CubeMX. |
 | `ccbhal`| `src/main_ccbhal.c`| CubeMX `HAL_CCB_*` reference flow (provision + sign + SW-verify), `u3` only. |
 | `cbonly`| `src/main_cbonly.c`| Callback-only: ECDSA, full-payload AES-GCM, HMAC-SHA256, TRNG all on hardware, with the `STM32_BARE_CB_ONLY` software-strip preset. |
+| `puf` | `src/main_puf.c` | Configurable SRAM PUF (BCH(127,k,t) fuzzy extractor + HKDF) enroll/reconstruct regression in synthetic-SRAM mode. `PUF_T` selects the BCH profile (7/10/13/15), `PUF_CW` the codeword count. |
 
 `TARGET=dhuk` is limited to the SAES + PKA + DHUK boards (`u3`, `u585`, `u545`) and adds `-DWOLFSSL_DHUK -DWOLF_CRYPTO_CB`, which enable the STM32 DHUK crypto-callback device (in `wolfcrypt/src/port/st/stm32.c`). An application registers the device once (`wc_Stm32_DhukRegister(WC_DHUK_DEVID)`), inits a normal `Aes` / `ecc_key` with `devId = WC_DHUK_DEVID`, supplies the 256-bit seed as the key (`wc_AesGcmSetKey` / `wc_AesSetKey`) or via `wc_ecc_import_wrapped_private`, then performs NORMAL wolfCrypt calls -- the device-bound key is derived inside SAES and never appears in software. `main_dhuk.c`:
 
@@ -297,6 +298,31 @@ Result: 0 (PASS)
 ```
 
 The AES-GCM leg validates enc/dec with a nonzero payload round-trip plus tamper rejection -- the right correctness bar for a device-bound key, whose value is never known so a fixed KAT cannot apply. Dropping the software crypto shrinks flash measurably: `parse_size.py` reports `cbonly` vs the full-software `dhuk` build at 9.7 KB saved on `u3` (12.3%), 11.8 KB on `u585` (15.0%), and 15.0 KB on `c5a3` (17.0%).
+
+### SRAM PUF regression (`TARGET=puf`)
+
+`TARGET=puf` builds `src/main_puf.c`, exercising the configurable wolfCrypt SRAM PUF (a BCH(127,k,t) fuzzy extractor with HKDF key derivation) end to end on real silicon in synthetic-SRAM mode (`WOLFSSL_PUF_TEST`), so it runs on any board with no board-specific NOLOAD section. Each run enrolls, reconstructs cleanly (identity and derived key must match), reconstructs at the `t`-bit correction limit (`t` flips per 128-bit block, must still match), and checks an over-limit `t+1`-flip case that must fail or produce a different identity rather than silently reproduce the enrolled key. It prints per-step PASS lines then `Result: 0 (PASS)` and `Test complete`. For the real power-on SRAM physical PUF, use the H5-specific `wolfssl-examples/puf` project instead.
+
+This target uses `wc_PufGetProfileId()`, `wc_PufGetHelperData()` and `wc_PufReconstructEx()`, so it needs a wolfSSL with the configurable-PUF work; it will not build against 5.9.2. Step `[0]` cross-checks the library's profile id against the application's, which is what catches a partial rebuild that mixes objects from two different profiles (the sizes of `wc_PufCtx` disagree and the context overruns memory), and step `[5]` confirms helper data from a foreign profile is refused rather than decoded into a silently wrong key.
+
+Two knobs select the variation, gated via `-DSTM32_BARE_PUF` (which enables `WOLFSSL_PUF` + `WOLFSSL_PUF_TEST` in `user_settings.h`; HKDF is already on): `PUF_T=<7|10|13|15>` picks the BCH profile (`-DWC_PUF_BCH_T`, default 10) and `PUF_CW=<n>` picks `WC_PUF_NUM_CODEWORDS` (default 16). Because `make` does not track CFLAGS changes, give each profile its own `BUILD_DIR` (or `make clean` between profiles) or the build silently reuses stale wrong-profile objects.
+
+```
+make BOARD=h5   CONFIG=bare TARGET=puf            flash   # default t=10
+make BOARD=h5   CONFIG=bare TARGET=puf PUF_T=13   flash
+make BOARD=f767 CONFIG=bare TARGET=puf PUF_T=7    flash
+```
+
+Validated on real silicon:
+
+| Board | Core | Variation | Result |
+|-------|------|-----------|--------|
+| NUCLEO-H563ZI | Cortex-M33 | t=7 / 10 / 13 / 15 | PASS |
+| NUCLEO-H563ZI | Cortex-M33 | t=10, cw=8 / cw=32 | PASS |
+| NUCLEO-G071RB | Cortex-M0+ | t=10 | PASS |
+| NUCLEO-F439ZI | Cortex-M4F | t=10, t=13 | PASS |
+| NUCLEO-F767ZI | Cortex-M7 | t=10, t=7 | PASS |
+| B-U585I-IOT02A | Cortex-M33 (TrustZone) | t=10 | PASS |
 
 ### Orthogonal axes
 

--- a/STM32_Bare_Test/src/main_puf.c
+++ b/STM32_Bare_Test/src/main_puf.c
@@ -1,0 +1,187 @@
+/* main_puf.c
+ *
+ * Copyright (C) 2026 wolfSSL Inc.
+ *
+ * SRAM PUF regression app for STM32_Bare_Test. Runs the wolfCrypt PUF fuzzy
+ * extractor end-to-end on real silicon in synthetic-SRAM mode
+ * (WOLFSSL_PUF_TEST): enroll, clean reconstruct, reconstruct at the t-bit
+ * correction limit, and an over-limit case that must not silently reproduce
+ * the enrolled key. Exercises whatever BCH profile the build selected
+ * (WC_PUF_BCH_T) and codeword count (WC_PUF_NUM_CODEWORDS).
+ *
+ *   make BOARD=h5 CONFIG=bare TARGET=puf PUF_T=13 flash
+ */
+
+#include <stdio.h>
+
+#include "board.h"
+
+extern uint32_t SystemCoreClock;
+extern void     SystemCoreClockUpdate(void);
+
+#include "wolfssl/wolfcrypt/settings.h"
+#include "wolfssl/version.h"
+#include "wolfssl/wolfcrypt/types.h"
+#include "wolfssl/wolfcrypt/wc_port.h"
+#include "wolfssl/wolfcrypt/error-crypt.h"
+#include "wolfssl/wolfcrypt/puf.h"
+
+#ifndef BUILD_CONFIG_NAME
+#define BUILD_CONFIG_NAME "unknown"
+#endif
+
+/* Deterministic, profile-agnostic fill of the raw SRAM image. */
+static void puf_fill(byte* sram, word32 sz)
+{
+    word32 i;
+    for (i = 0; i < sz; i++)
+        sram[i] = (byte)((i * 167u + 13u) ^ (i << 3));
+}
+
+/* Flip 'count' distinct bits inside one 128-bit codeword block, spread 7
+ * apart so up to t+1 flips stay within the used n=127 bits. */
+static void puf_flip(byte* sram, int block, int count)
+{
+    int i, base = block * 128;
+    for (i = 0; i < count; i++) {
+        int p = base + i * 7;
+        sram[p / 8] ^= (byte)(1 << (7 - (p % 8)));
+    }
+}
+
+int main(void)
+{
+    wc_PufCtx ctx;
+    byte sram[WC_PUF_RAW_BYTES];
+    byte noisy[WC_PUF_RAW_BYTES];
+    byte helper[WC_PUF_HELPER_BYTES];
+    byte id1[WC_PUF_ID_SZ], id2[WC_PUF_ID_SZ];
+    byte key1[WC_PUF_KEY_SZ], key2[WC_PUF_KEY_SZ];
+    const byte info[] = "stm32-puf";
+    int m, n, k, t, nc, nb, b;
+    int ret = 0;
+    int fail = 0;
+
+    board_init();
+    SystemCoreClockUpdate();
+
+    wc_PufGetParams(&m, &n, &k, &t, &nc);
+
+    printf("\n");
+    printf("========================================\n");
+    printf("wolfCrypt SRAM PUF - %s (CONFIG=%s)\n",
+           board_name(), BUILD_CONFIG_NAME);
+    printf("wolfSSL version: %s\n", LIBWOLFSSL_VERSION_STRING);
+    printf("PUF profile: BCH(%d,%d,t=%d) codewords=%d "
+           "raw=%d helper=%d\n", n, k, t, nc,
+           (int)WC_PUF_RAW_BYTES, (int)WC_PUF_HELPER_BYTES);
+    printf("profile id: app %08lX  lib %08lX\n",
+           (unsigned long)WC_PUF_PROFILE_ID,
+           (unsigned long)wc_PufGetProfileId());
+    printf("========================================\n\n");
+
+    /* A partial rebuild that mixes, say, a t=13 application with t=10 library
+     * objects gives the two sides different sizeof(wc_PufCtx) and corrupts
+     * memory on the first call. Catch it here instead. */
+    if (wc_PufGetProfileId() != (word32)WC_PUF_PROFILE_ID) {
+        printf("[0] profile: FAIL (library/application mismatch)\n");
+        printf("\nResult: 1 (FAIL)\nTest complete\n");
+        for (;;) { }
+    }
+
+    ret = wolfCrypt_Init();
+    if (ret != 0) {
+        printf("wolfCrypt_Init failed: %d\n", ret);
+        printf("Result: %d (FAIL)\nTest complete\n", ret);
+        for (;;) { }
+    }
+
+    puf_fill(sram, (word32)sizeof(sram));
+    nb = nc < 3 ? nc : 3;
+
+    /* [1] enroll */
+    if (wc_PufInit(&ctx) != 0 ||
+        wc_PufSetTestData(&ctx, sram, sizeof(sram)) != 0 ||
+        wc_PufReadSram(&ctx, sram, sizeof(sram)) != 0 ||
+        wc_PufEnroll(&ctx) != 0) {
+        printf("[1] enroll: FAIL\n"); fail = 1; goto done;
+    }
+    if (wc_PufGetHelperData(&ctx, helper, sizeof(helper)) != 0 ||
+        wc_PufGetIdentity(&ctx, id1, sizeof(id1)) != 0 ||
+        wc_PufDeriveKey(&ctx, info, sizeof(info), key1, sizeof(key1)) != 0) {
+        printf("[1] enroll: FAIL\n"); fail = 1; goto done;
+    }
+    printf("[1] enroll: PASS\n");
+
+    /* [2] clean reconstruct - identity + key must match */
+    if (wc_PufInit(&ctx) != 0 ||
+        wc_PufSetTestData(&ctx, sram, sizeof(sram)) != 0 ||
+        wc_PufReadSram(&ctx, sram, sizeof(sram)) != 0 ||
+        wc_PufReconstructEx(&ctx, helper, sizeof(helper),
+            (word32)WC_PUF_PROFILE_ID) != 0 ||
+        wc_PufGetIdentity(&ctx, id2, sizeof(id2)) != 0 ||
+        XMEMCMP(id1, id2, WC_PUF_ID_SZ) != 0 ||
+        wc_PufDeriveKey(&ctx, info, sizeof(info), key2, sizeof(key2)) != 0 ||
+        XMEMCMP(key1, key2, WC_PUF_KEY_SZ) != 0) {
+        printf("[2] clean reconstruct: FAIL\n"); fail = 1; goto done;
+    }
+    printf("[2] clean reconstruct: PASS\n");
+
+    /* [3] reconstruct at the t-bit correction limit */
+    XMEMCPY(noisy, sram, sizeof(sram));
+    for (b = 0; b < nb; b++)
+        puf_flip(noisy, b, t);
+    if (wc_PufInit(&ctx) != 0 ||
+        wc_PufSetTestData(&ctx, noisy, sizeof(noisy)) != 0 ||
+        wc_PufReadSram(&ctx, noisy, sizeof(noisy)) != 0 ||
+        wc_PufReconstruct(&ctx, helper, sizeof(helper)) != 0 ||
+        wc_PufGetIdentity(&ctx, id2, sizeof(id2)) != 0 ||
+        XMEMCMP(id1, id2, WC_PUF_ID_SZ) != 0) {
+        printf("[3] reconstruct t=%d flips/block: FAIL\n", t);
+        fail = 1; goto done;
+    }
+    printf("[3] reconstruct %d flips/block x %d: PASS\n", t, nb);
+
+    /* [4] over-limit: t+1 flips must fail OR differ, never silently correct */
+    XMEMCPY(noisy, sram, sizeof(sram));
+    puf_flip(noisy, 0, t + 1);
+    if (wc_PufInit(&ctx) != 0 ||
+        wc_PufSetTestData(&ctx, noisy, sizeof(noisy)) != 0 ||
+        wc_PufReadSram(&ctx, noisy, sizeof(noisy)) != 0) {
+        printf("[4] over-limit: FAIL (setup)\n"); fail = 1; goto done;
+    }
+    /* a successful decode must not reproduce the enrolled identity or key */
+    if (wc_PufReconstruct(&ctx, helper, sizeof(helper)) == 0) {
+        if (wc_PufGetIdentity(&ctx, id2, sizeof(id2)) == 0 &&
+                XMEMCMP(id1, id2, WC_PUF_ID_SZ) == 0) {
+            printf("[4] over-limit: FAIL (identity reproduced)\n");
+            fail = 1; goto done;
+        }
+        if (wc_PufDeriveKey(&ctx, info, sizeof(info), key2,
+                sizeof(key2)) == 0 &&
+                XMEMCMP(key1, key2, WC_PUF_KEY_SZ) == 0) {
+            printf("[4] over-limit: FAIL (key reproduced)\n");
+            fail = 1; goto done;
+        }
+    }
+    printf("[4] over-limit t+1: PASS\n");
+
+    /* [5] helper data from a differently configured build must be refused
+     * rather than decoded into a silently wrong key */
+    if (wc_PufInit(&ctx) != 0 ||
+        wc_PufSetTestData(&ctx, sram, sizeof(sram)) != 0 ||
+        wc_PufReadSram(&ctx, sram, sizeof(sram)) != 0) {
+        printf("[5] profile mismatch: FAIL (setup)\n"); fail = 1; goto done;
+    }
+    if (wc_PufReconstructEx(&ctx, helper, sizeof(helper),
+            ((word32)WC_PUF_PROFILE_ID) ^ 1u) != BAD_FUNC_ARG) {
+        printf("[5] profile mismatch: FAIL (not rejected)\n");
+        fail = 1; goto done;
+    }
+    printf("[5] foreign profile id rejected: PASS\n");
+
+done:
+    printf("\nResult: %d (%s)\n", fail, fail ? "FAIL" : "PASS");
+    printf("Test complete\n");
+    for (;;) { }
+}

--- a/STM32_Bare_Test/user_settings.h
+++ b/STM32_Bare_Test/user_settings.h
@@ -690,6 +690,15 @@ extern "C" {
 /* HMAC / KDF */
 #define HAVE_HKDF
 
+/* SRAM PUF regression (TARGET=puf). Synthetic-SRAM test mode so it
+ * runs on any board without a board-specific NOLOAD section. HKDF is
+ * already enabled above. WC_PUF_BCH_T / WC_PUF_NUM_CODEWORDS come from
+ * the build command (PUF_T / PUF_CW). */
+#ifdef STM32_BARE_PUF
+    #define WOLFSSL_PUF
+    #define WOLFSSL_PUF_TEST
+#endif
+
 /* ChaCha20-Poly1305 */
 #define HAVE_CHACHA
 #define HAVE_POLY1305


### PR DESCRIPTION
## Summary

Adds a `puf` build target that exercises the configurable wolfCrypt SRAM PUF on STM32 hardware.

## Features

- `TARGET=puf` runs enroll, clean reconstruct, reconstruct at the t-bit correction limit, and an over-limit case (must fail or differ, never silently reproduce the enrolled key). It uses synthetic-SRAM mode so it runs on any board with no board-specific NOLOAD section.
- `PUF_T` selects the BCH error-correction profile (7/10/13/15) and `PUF_CW` the codeword count.
- README documents the target and the on-silicon results.

## Testing

Validated on real silicon: NUCLEO-H563ZI (t=7/10/13/15 and cw=8/32), plus portability across NUCLEO-G071RB (M0+), NUCLEO-F439ZI (M4), NUCLEO-F767ZI (M7), and B-U585I-IOT02A (M33).

Requires https://github.com/wolfSSL/wolfssl/pull/11057