### PR TITLE
Add NUCLEO-V873XJ (STM32V8, Cortex-M85) board support

### DIFF
--- a/STM32_Bare_Test/Makefile
+++ b/STM32_Bare_Test/Makefile
@@ -46,21 +46,27 @@ BUILD    ?= bare
 PQC      ?= 0
 STACK    ?= 0
 
-ifeq ($(filter $(BOARD),c031 h5 h573 h7 h7a3 h7s3 h723 u5 u3 u585 u545 u083 f207 f303 f437 f439 f767 wb55 wl55 g071 g474 g491 wba52 n657 c562 c5a3 l4a6 l552 l562),)
-  $(error BOARD must be one of: c031 | h5 | h573 | h7 | h7a3 | h7s3 | h723 | u5 | u3 | u585 | u545 | u083 | f207 | f303 | f437 | f439 | f767 | wb55 | wl55 | g071 | g474 | g491 | wba52 | n657 | c562 | c5a3 | l4a6 | l552 | l562)
+ifeq ($(filter $(BOARD),c031 h5 h573 h7 h7a3 h7s3 h723 u5 u3 u585 u545 u083 f207 f303 f437 f439 f767 wb55 wl55 g071 g474 g491 wba52 n657 c562 c5a3 l4a6 l552 l562 v8),)
+  $(error BOARD must be one of: c031 | h5 | h573 | h7 | h7a3 | h7s3 | h723 | u5 | u3 | u585 | u545 | u083 | f207 | f303 | f437 | f439 | f767 | wb55 | wl55 | g071 | g474 | g491 | wba52 | n657 | c562 | c5a3 | l4a6 | l552 | l562 | v8)
 endif
 
 ifeq ($(filter $(CONFIG),c asm bare),)
   $(error CONFIG must be one of: c | asm | bare)
 endif
-ifeq ($(filter $(TARGET),test bench dhuk stsaes ccb ccbhal c5rng c5sign cbonly puf cubeaes cubecrypto aesplain plaingcm gcmalign),)
-  $(error TARGET must be one of: test | bench | dhuk | stsaes | ccb | ccbhal | c5rng | c5sign | cbonly | puf | cubeaes | cubecrypto | aesplain | plaingcm | gcmalign)
+ifeq ($(filter $(TARGET),test bench dhuk stsaes ccb ccbhal c5rng c5sign cbonly puf cubeaes cubecrypto aesplain plaingcm gcmalign v8sha3),)
+  $(error TARGET must be one of: test | bench | dhuk | stsaes | ccb | ccbhal | c5rng | c5sign | cbonly | puf | cubeaes | cubecrypto | aesplain | plaingcm | gcmalign | v8sha3)
 endif
 # c5rng: bare register-level STM32C5 HW-RNG conditioning probe (no wolfCrypt).
 # c5sign: bare STM32C5 PROTECTED ECDSA-sign probe driving ST's NIST P-256 CAVP
 # vector through the PKA registers directly, compared to ST's expected R,S.
 # Runs ST's CCB_RNG_Init / CONDRST + NIST sequence on live silicon and reports
 # the precise failure mode. C5 boards only.
+# v8sha3: bare register-level STM32V8 HASH SHA-3/SHAKE probe (no wolfCrypt).
+ifeq ($(TARGET),v8sha3)
+  ifneq ($(BOARD),v8)
+    $(error TARGET=v8sha3 requires BOARD=v8)
+  endif
+endif
 ifneq ($(filter $(TARGET),c5rng c5sign),)
   ifeq ($(filter $(BOARD),c5a3 c562),)
     $(error TARGET=$(TARGET) requires a C5 board: c5a3 | c562)
@@ -216,6 +222,11 @@ ifeq ($(PQC),1)
 else
   PQC_DEFS :=
 endif
+ifeq ($(SHA3_ASM),1)
+  SHA3_DEFS := -DSTM32_BARE_SHA3_ASM
+else
+  SHA3_DEFS :=
+endif
 
 # STACK=1 enables per-algorithm peak stack + peak heap reporting. The
 # actual #defines (USE_WOLFSSL_MEMORY, WOLFSSL_TRACK_MEMORY_VERBOSE,
@@ -262,10 +273,12 @@ else
   PUF_DEFS :=
 endif
 
-COMMON_DEFS := -DWOLFSSL_USER_SETTINGS $(CPU_DEFS) $(VARIANT_DEFS) $(BUILD_DEFS) $(PQC_DEFS) $(STACK_DEFS) $(GCM_DEFS) $(PUF_DEFS)
+COMMON_DEFS := -DWOLFSSL_USER_SETTINGS $(CPU_DEFS) $(VARIANT_DEFS) $(BUILD_DEFS) $(PQC_DEFS) $(SHA3_DEFS) $(STACK_DEFS) $(GCM_DEFS) $(PUF_DEFS)
 
+# Optimization level, overridable for miscompile/UB bisects: make OPT=-O1 ...
+OPT ?= -O2
 CFLAGS    = $(MCU_FLAGS) $(INCLUDES) $(COMMON_DEFS) \
-            -O2 -fomit-frame-pointer \
+            $(OPT) -fomit-frame-pointer \
             -ffunction-sections -fdata-sections \
             -Wall -Wno-unused-function -Wno-unused-variable \
             -fno-common -fno-strict-aliasing \
@@ -335,9 +348,14 @@ WC_SRC += \
 # WOLFSSL_ARMASM is active AND ML-KEM is enabled. PQC=1 enables ML-KEM,
 # so wire it in only there. (thumb2-sha3-asm_c.c also exists upstream
 # but adding it unconditionally pushes wl55 over its 256 KB flash, so
-# SHA3 stays on the C path via WC_SHA3_NO_ASM in user_settings.h.)
+# SHA3 stays on the C path via WC_SHA3_NO_ASM in user_settings.h.
+# SHA3_ASM=1 opts in on large-flash boards: 2.5x SHA-3/SHAKE and 2x
+# ML-DSA sign measured on the 4 MB v8.)
 ifeq ($(PQC),1)
   WC_SRC += $(WC_SRC_DIR)/port/arm/thumb2-mlkem-asm_c.c
+endif
+ifeq ($(SHA3_ASM),1)
+  WC_SRC += $(WC_SRC_DIR)/port/arm/thumb2-sha3-asm_c.c
 endif
 
 # Target entry point

--- a/STM32_Bare_Test/README.md
+++ b/STM32_Bare_Test/README.md
@@ -40,6 +40,7 @@ HW ECDSA-sign; `l552` and `h573` have no board available).
 | `h5`   | STM32H563ZI   | Validated 6/4 | NUCLEO-H563ZI. Full wolfcrypt_test PASS. HW HASH + RNG; ECC in software (H563 PKA ECDSA erratum, see note). FIXED boot fault (VOS0) |
 | `c031` | STM32C031C6   | Validated 6/4 | NUCLEO-C031C6. RNG-only (Cortex-M0+). Earlier no-UART was a flaky ST-LINK connection; re-seating the probe resolved it |
 | `u083` | STM32U083RC   | Not run 6/3   | NUCLEO-U083RC. RNG only. Not attached this session  |
+| `v8`   | STM32V873XJ   | Validated 8/25 | NUCLEO-V873XJ (Cortex-M85, 4 MB). Full wolfcrypt_test PASS + bench PASS; HW RNG + HASH(SHA-1/2) + SAES-AES + PKA ECDSA validated (SHA-3/SHAKE register-level only, wolfSSL integration pending ctx-save procedure); benched at 250/496/800 MHz. Secure-state image at 0x18000000/0x34000000 (no TZEN option byte). CMSIS header is GENERATED from the CubeProgrammer SVD -- see boards/v8/tools/svd2cmsis.py, output not checked in. No UART yet: board_putc writes a .noinit RAM ring buffer read back over SWD. I-cache on, D-cache off (breaks output). SYSCLK 250 MHz measured, CPU_FREQ_BOOST disabled |
 | `l552` | STM32L552ZE   | Not run 6/3   | NUCLEO-L552ZE-Q. Not attachable this session        |
 | `h573` | STM32H573ZI   | No board      | NUCLEO-H573ZI not available. Build OK               |
 

--- a/STM32_Bare_Test/bench_matrix.sh
+++ b/STM32_Bare_Test/bench_matrix.sh
@@ -54,6 +54,9 @@ declare -A PTY_NAME=(
     [u5]=NUCLEO_U575ZI_Q_UART
     [u545]=NUCLEO_U545RE_Q_UART
     [u585]=B_U585I_IOT02A_UART
+    # v8 has no UART yet -- console is a .noinit RAM buffer read over SWD.
+    # This name is aspirational; not a working capture source until UART lands.
+    [v8]=STM32_STLINK_V3_UART_34313937
     [wb55]=NUCLEO_WB55RG_UART
     [wba52]=NUCLEO_WBA52CG_UART
     [wl55]=NUCLEO_WL55JC_UART
@@ -63,6 +66,7 @@ declare -A PTY_NAME=(
 # Format: "<board>:<reason>".
 declare -A EXCLUDE=(
     [c031]="bench overflows 32 KB flash"
+    [v8]="passes but runs uncached (~20min/config); enable caches before sweeping"
 )
 
 # Per (board,config) skip set: M0/M0+ cannot build the asm config.
@@ -73,7 +77,7 @@ declare -A SKIP_BOARD_CONFIG=(
 
 # ---- Argument parsing ----------------------------------------------------
 ALL_BOARDS=(c562 c5a3 f207 f303 f437 f439 f767 g071 g474 g491 h5 h573 h7 h723 \
-            h7a3 h7s3 l4a6 l552 l562 n657 u083 u3 u5 u545 u585 wb55 wba52 wl55)
+            h7a3 h7s3 l4a6 l552 l562 n657 u083 u3 u5 u545 u585 v8 wb55 wba52 wl55)
 ALL_CONFIGS=(bare asm c)
 
 BOARDS_ARG=""

--- a/STM32_Bare_Test/boards/common/board-derive.mk
+++ b/STM32_Bare_Test/boards/common/board-derive.mk
@@ -20,7 +20,8 @@
 #   b_system        board system_stm32*.c source
 # Optional overrides:
 #   b_chipdef       -D token if not STM32<upper(b_chip)>xx (h7a3, f303)
-#   b_extra_defs    extra CPU_DEFS appended unconditionally (wl55 -DCORE_CM4)
+#   b_extra_defs    extra compiler flags appended to CPU_DEFS unconditionally
+#                   (defines or tuning flags: wl55 -DCORE_CM4, v8 -mtune=...)
 #   b_hal_v2        1 -> add -DSTM32_HAL_V2 under BUILD=cubemx (f4 v1.28+, u0)
 #   b_ldsuffix      ld basename suffix, default "flat" (n657/h7s3 use "lrun")
 #   STLINK_SERIAL / USE_CUBE_PROGRAMMER / LDSCRIPT / STARTUP_S /
@@ -66,6 +67,17 @@ ifndef MCU_FLAGS
   endif
   ifeq ($(b_core),m55)
     MCU_FLAGS := -mcpu=cortex-m55 -mthumb -mfpu=fpv5-d16 -mfloat-abi=hard
+  endif
+  # Cortex-M85 (Armv8.1-M, STM32V8). No -mfpu=: -mcpu=cortex-m85 already
+  # selects the correct FPU. +nomve is load-bearing -- GCC defines
+  # __ARM_FEATURE_MVE 3 by default on this core, so without it the
+  # autovectorizer quietly puts Helium into what we report as the pure
+  # software baseline. Use b_core=m85_mve for the deliberate A/B.
+  ifeq ($(b_core),m85)
+    MCU_FLAGS := -mcpu=cortex-m85+nomve -mthumb -mfloat-abi=hard
+  endif
+  ifeq ($(b_core),m85_mve)
+    MCU_FLAGS := -mcpu=cortex-m85 -mthumb -mfloat-abi=hard
   endif
   ifndef MCU_FLAGS
     $(error board.mk for $(BOARD) set b_core=$(b_core) which board-derive.mk \

--- a/STM32_Bare_Test/boards/common/board_common.c
+++ b/STM32_Bare_Test/boards/common/board_common.c
@@ -59,6 +59,8 @@
     #include "stm32wbaxx.h"
 #elif defined(STM32_BOARD_C562) || defined(STM32_BOARD_C5A3)
     #include "stm32c5xx.h"
+#elif defined(STM32_BOARD_V8)
+    #include "stm32v8xx.h"
 #else
     #error "boards/common/board_common.c: unknown STM32_BOARD_* family"
 #endif
@@ -221,9 +223,12 @@ int _write(int file, char *ptr, int len)
  * Cortex-M0/M0+ have no CFSR / HFSR / MMFAR / BFAR -- skip those reads
  * on architectures without them (gated on __CORTEX_M >= 3). */
 #if !defined(__ARM_ARCH_6M__)
-/* Externally-visible (naked asm trampoline jumps to it by name). */
+/* Externally-visible (naked asm trampoline jumps to it by name). Weak so a
+ * board can override it -- e.g. to record registers with raw stores before
+ * attempting printf, which itself hangs if the fault was taken inside
+ * printf/malloc. */
 void wc_fault_dump(uint32_t *frame, const char *which);
-void wc_fault_dump(uint32_t *frame, const char *which)
+__attribute__((weak)) void wc_fault_dump(uint32_t *frame, const char *which)
 {
     /* Stack frame on entry: R0,R1,R2,R3,R12,LR,PC,xPSR */
     printf("\n[FAULT] %s\n", which);

--- a/STM32_Bare_Test/boards/v8/board.mk
+++ b/STM32_Bare_Test/boards/v8/board.mk
@@ -1,0 +1,71 @@
+# NUCLEO-V873XJ (STM32V873XJ): Cortex-M85 (Armv8.1-M + Helium), 4 MB flash.
+# Per STM32CubeProgrammer 2.22.0's SVD/STM32V873.svd: CRYP (fat, AES-192 +
+# GCM/CCM) + SAES (DHUK/BHK) + HASH (new-gen) + PKA (V2, sign and verify) +
+# RNG + CCB, all on RCC_AHB3ENR bits 0/1/2/3/8/15 -- an N6-shaped topology.
+#
+# No TZEN option byte: both flash-bank watermarks are secure and BOOTADD is
+# 0x18000000, so it always boots Secure and everything is linked through the
+# secure aliases (flash 0x18000000, AXI SRAM 0x34000000, peripherals
+# +0x10000000). HW RNG/HASH/SAES/PKA are enabled and validated on silicon.
+
+# ST publishes no stm32v8xx_dfp, so the device header is generated locally --
+# see the guard below. Override the location with STM32V8_DFP=...
+STM32V8_DFP ?= $(HOME)/Projects/STM/STM32V8/stm32v8xx_dfp
+CUBE_DIR    := $(STM32V8_DFP)
+CMSIS_DEVICE ?= $(CUBE_DIR)/Include
+
+# Cortex-M85 CMSIS-Core, borrowed from the installed CMSIS 6.3.0 pack (the N6
+# Cube FW pack carries an identical core_cm85.h).
+CMSIS_CORE ?= $(HOME)/.local/share/stm32cube/packs/STMicroelectronics/CMSIS/6.3.0/CMSIS/Core/Include
+
+# wolfcrypt_test can freeze in ed25519 (no fault, debug port dead) in a way
+# that toggles with ANY code-placement change: -O1 vs -O2, -mtune, inserted
+# printfs, or enabling unrelated features. -mtune=cortex-m33 helped one
+# specific config but is NOT a reliable fix. Mechanism open; prime suspect
+# is the flash fetch path (boot-ROM wait-states, uncached execution) or a
+# silicon erratum. Next: run from SRAM (ST's RAM.ld) to isolate. Keep the
+# tune flag meanwhile -- harmless and it stabilized several configs.
+b_extra_defs += -mtune=cortex-m33
+
+b_chip    := v873
+b_core    := m85
+b_chipdef := STM32V873xx
+b_serial  := 002000303434511734313937
+
+# C-file startup (no .s), same arrangement as c5a3/c562.
+STARTUP_S   :=
+BOARD_C_SRC := boards/v8/startup_stm32v873xx.c boards/v8/hw_init.c
+
+# ST publishes no stm32v8xx_dfp, so the CMSIS device header is generated
+# locally from the SVD that ships with STM32CubeProgrammer 2.22.0:
+#
+#   ./boards/v8/tools/svd2cmsis.py \
+#       --svd ~/STMicroelectronics/STM32Cube/STM32CubeProgrammer/SVD/STM32V873.svd \
+#       --out $(STM32V8_DFP)/Include
+#
+# The generated header is ST-derived and is deliberately NOT checked in --
+# treat it like a vendor DFP. Only the generator (our code) is in the tree.
+ifeq ($(wildcard $(CMSIS_DEVICE)/stm32v8xx.h),)
+  $(error BOARD=v8 needs the CMSIS device header at $(CMSIS_DEVICE). \
+          Generate it with boards/v8/tools/svd2cmsis.py -- see the comment \
+          in boards/v8/board.mk. Override the location with STM32V8_DFP=)
+endif
+ifeq ($(wildcard $(CMSIS_CORE)/core_cm85.h),)
+  $(error BOARD=v8 needs core_cm85.h at $(CMSIS_CORE) (CMSIS 6.x pack). \
+          Override the location with CMSIS_CORE=)
+endif
+
+# OpenOCD has no stm32v8x.cfg, and only CubeProgrammer 2.22.0+ knows device
+# ID 0x499. NOTE: ~/.local/bin/STM32_Programmer_CLI is a symlink to the
+# CubeIDE 2.0.0 bundle (2.21.0) which does NOT know this part -- point at
+# the standalone install explicitly.
+# The Makefile's CUBE_PROGRAMMER default already points at the standalone
+# install and its flash rule already uses mode=UR -- which this part
+# requires, since mode=HOTPLUG fails against the running secure firmware
+# with "Unable to get core ID". So no override is needed here.
+USE_CUBE_PROGRAMMER := 1
+
+# BUILD=cubemx is not wired yet (V8 ships new-generation HAL like C5, and
+# no pack exists publicly). Leaving HAL_FAMILY empty makes the harness
+# reject BUILD=cubemx with its normal guard rather than failing obscurely.
+HAL_FAMILY :=

--- a/STM32_Bare_Test/boards/v8/hw_init.c
+++ b/STM32_Bare_Test/boards/v8/hw_init.c
@@ -1,0 +1,321 @@
+/* hw_init.c - NUCLEO-V873XJ (STM32V873XJ, Cortex-M85) bring-up
+ *
+ * Copyright (C) 2026 wolfSSL Inc.
+ *
+ * The VCP USART is not identified yet (the SVD carries no pin muxing and the
+ * factory image clocks no USART), so board_putc() writes a RAM ring buffer
+ * the host reads over SWD instead of driving a UART.
+ *
+ * Addressing uses the Secure aliases: the part has no TZEN option byte, both
+ * flash-bank watermarks are secure and BOOTADD is 0x18000000, so it always
+ * runs Secure. A CMSIS header built without -mcmse resolves the plain names
+ * to the non-secure aliases, which RIFSC blocks.
+ */
+
+#include "stm32v8xx.h"
+#include "board.h"
+#include <stdio.h>
+
+/* Defined weak in boards/common/board_common.c; no system_stm32v8xx.c here. */
+extern uint32_t SystemCoreClock;
+
+#ifndef V8_SYSCLK_HZ
+/* MEASURED, not read from RCC: the PLL is not configured here and no
+ * reference manual is public, so the clock was calibrated against host
+ * wall-clock (benchmark self-reported 66.0 s while really taking 16.8 s,
+ * ratio 3.93 against the assumed 64 MHz). benchmark.c times with SysTick,
+ * so a wrong value here silently scales every reported rate. Note
+ * CPU_FREQ_BOOST is disabled in the option bytes, so this is not the
+ * part's 800 MHz rate. */
+#define V8_SYSCLK_HZ 250000000u
+#endif
+
+/* Cache enables, individually overridable from the build. */
+#ifndef V8_ENABLE_ICACHE
+#define V8_ENABLE_ICACHE 1
+#endif
+#ifndef V8_ENABLE_DCACHE
+#define V8_ENABLE_DCACHE 0
+#endif
+/* Explicit MPU memory attributes. The Armv8-M default map nominally makes
+ * flash and SRAM cacheable, but the D-cache does not behave with it on this
+ * part, so state the attributes rather than inherit them. */
+#ifndef V8_ENABLE_MPU
+#define V8_ENABLE_MPU 0
+#endif
+
+#ifndef V8_CONSOLE_SIZE
+#define V8_CONSOLE_SIZE 16384u
+#endif
+
+#define V8_CONSOLE_MAGIC 0x56384C47u  /* 'V8LG' */
+
+/* Read back over SWD:
+ *   arm-none-eabi-nm app.elf | grep v8_console
+ *   STM32_Programmer_CLI -c port=swd sn=<SN> mode=UR -r32 <addr> <len>
+ * 'wrote' keeps counting past V8_CONSOLE_SIZE so truncation is detectable. */
+typedef struct {
+    volatile uint32_t magic;
+    volatile uint32_t wrote;
+    volatile uint32_t overflow;
+    volatile uint32_t boots;     /* increments per run - detects re-runs */
+    volatile uint8_t  buf[V8_CONSOLE_SIZE];
+} v8_console_t;
+
+/* .noinit so a mode=UR connect (which resets the part) does not wipe the log
+ * from the run we are trying to read. aligned(8) is sufficient: CMSIS 6.x
+ * SCB_CleanDCache_by_Addr covers partial lines (DCCMVAC ignores bits 4:0),
+ * and raising to aligned(32) changes board_putc codegen, which re-triggers
+ * the placement-sensitive freeze (see board.mk). */
+volatile v8_console_t v8_console
+    __attribute__((used, aligned(8), section(".noinit")));
+
+void board_putc(int ch)
+{
+    uint32_t idx;
+
+    idx = v8_console.wrote;
+    if (idx < V8_CONSOLE_SIZE) {
+        v8_console.buf[idx] = (uint8_t)ch;
+    }
+    else {
+        v8_console.overflow = 1u;
+    }
+    v8_console.wrote = idx + 1u;
+
+    /* The console is read back over SWD, and the debug access port reads
+     * through the bus -- it does not snoop the D-cache. With the D-cache
+     * enabled a dirty line would leave the host reading stale bytes, which
+     * looks exactly like the log having stopped. Clean the header and the
+     * touched cache line so what the host sees is what we wrote. */
+    if ((SCB->CCR & SCB_CCR_DC_Msk) != 0u) {
+        SCB_CleanDCache_by_Addr((uint32_t *)(void *)&v8_console, 32);
+        if (idx < V8_CONSOLE_SIZE) {
+            SCB_CleanDCache_by_Addr(
+                (uint32_t *)(void *)&v8_console.buf[idx & ~((uint32_t)31)], 32);
+        }
+    }
+}
+
+/* Raw fault record: plain word stores, no printf, so it survives a fault
+ * taken inside printf/malloc (where the shared WC_FAULT_HANDLER's own printf
+ * would hang silently). magic 'V8FR' when written. Read over SWD:
+ *   nm app.elf | grep v8_fault ; -r32 <addr> 48 */
+#define V8_FAULT_MAGIC 0x56384652u
+
+typedef struct {
+    volatile uint32_t magic;
+    volatile uint32_t r0, r1, r2, r3, r12, lr, pc, xpsr;
+    volatile uint32_t cfsr, hfsr, mmfar, bfar;
+} v8_fault_t;
+volatile v8_fault_t v8_fault __attribute__((used, aligned(8), section(".noinit")));
+
+__attribute__((used)) void v8_fault_record(uint32_t *frame)
+{
+    v8_fault.r0    = frame[0];
+    v8_fault.r1    = frame[1];
+    v8_fault.r2    = frame[2];
+    v8_fault.r3    = frame[3];
+    v8_fault.r12   = frame[4];
+    v8_fault.lr    = frame[5];
+    v8_fault.pc    = frame[6];
+    v8_fault.xpsr  = frame[7];
+    v8_fault.cfsr  = SCB->CFSR;
+    v8_fault.hfsr  = SCB->HFSR;
+    v8_fault.mmfar = SCB->MMFAR;
+    v8_fault.bfar  = SCB->BFAR;
+    v8_fault.magic = V8_FAULT_MAGIC;
+}
+
+/* Override the shared handler: raw-record first (survives a fault taken
+ * inside printf/malloc), then attempt the readable printf dump. */
+void wc_fault_dump(uint32_t *frame, const char *which)
+{
+    v8_fault_record(frame);
+    printf("\n[FAULT] %s pc=0x%08lx lr=0x%08lx cfsr=0x%08lx\n",
+        which, (unsigned long)frame[6], (unsigned long)frame[5],
+        (unsigned long)SCB->CFSR);
+    for (;;) { }
+}
+
+/* Fault handlers come from boards/common/board_common.c (WC_FAULT_HANDLER),
+ * which printfs CFSR/HFSR and the stacked PC -- and printf lands in
+ * v8_console, so a fault is visible in the SWD read-back. Note a true
+ * LOCKUP (double fault, e.g. a stack overflow that corrupts the exception
+ * frame) runs no handler at all, so an abrupt end to the log with no
+ * [FAULT] line is itself diagnostic. */
+
+static void v8_dump_rcc(void);
+#ifdef V8_TRY_PLL
+static uint32_t v8_pll_hz = 0u;
+#endif
+
+void board_init(void)
+{
+    /* Fresh log per run; boots counts how many times we came through here so
+     * a stale buffer cannot be mistaken for a live one. */
+    v8_console.boots    = (v8_console.magic == V8_CONSOLE_MAGIC)
+                          ? v8_console.boots + 1u : 1u;
+    v8_console.magic    = V8_CONSOLE_MAGIC;
+    v8_console.wrote    = 0u;
+    v8_console.overflow = 0u;
+
+    /* The boot ROM hands off with its own MPU configuration in place; clear
+     * it so our map applies. */
+    ARM_MPU_Disable();
+
+#if V8_ENABLE_MPU
+    /* attr0 Normal write-back R/W-allocate, attr1 Device-nGnRE. */
+    ARM_MPU_SetMemAttr(0u, ARM_MPU_ATTR(
+        ARM_MPU_ATTR_MEMORY_(1u, 1u, 1u, 1u),
+        ARM_MPU_ATTR_MEMORY_(1u, 1u, 1u, 1u)));
+    ARM_MPU_SetMemAttr(1u, ARM_MPU_ATTR(
+        ARM_MPU_ATTR_DEVICE, ARM_MPU_ATTR_DEVICE_nGnRE));
+
+    /* Secure flash: executable, read-only, cacheable. */
+    ARM_MPU_SetRegion(0u,
+        ARM_MPU_RBAR(0x18000000u, ARM_MPU_SH_NON, 1u, 1u, 0u),
+        ARM_MPU_RLAR(0x183FFFFFu, 0u));
+    /* Secure AXI SRAM: read/write, execute-never, cacheable. */
+    ARM_MPU_SetRegion(1u,
+        ARM_MPU_RBAR(0x34000000u, ARM_MPU_SH_NON, 0u, 1u, 1u),
+        ARM_MPU_RLAR(0x340FFFFFu, 0u));
+    /* Peripherals (both aliases): Device, execute-never. */
+    ARM_MPU_SetRegion(2u,
+        ARM_MPU_RBAR(0x40000000u, ARM_MPU_SH_NON, 0u, 1u, 1u),
+        ARM_MPU_RLAR(0x5FFFFFFFu, 1u));
+
+    /* PRIVDEFENA so anything not covered falls back to the default map. */
+    ARM_MPU_Enable(MPU_CTRL_PRIVDEFENA_Msk);
+#endif
+
+    /* Take faults in our own handlers rather than escalating to a ROM
+     * lockup, so a bad access is debuggable. */
+    SCB->SHCSR |= (SCB_SHCSR_BUSFAULTENA_Msk |
+                   SCB_SHCSR_MEMFAULTENA_Msk |
+                   SCB_SHCSR_USGFAULTENA_Msk);
+
+    /* Full access to CP10/CP11 (FPU). */
+    SCB->CPACR |= ((3u << 20) | (3u << 22));
+    __DSB();
+    __ISB();
+
+    /* I-cache on, D-cache off. Measured on this board: I-cache is worth
+     * 1.4x to 2.7x (SHA-256 1.11 -> 2.75 MiB/s, ECDSA P-256 sign 324.8 ->
+     * 122.5 ms). D-cache enable returns and board_init() completes, but the
+     * first printf then emits nothing; explicit MPU attributes did not help.
+     * Override either with -DV8_ENABLE_ICACHE / -DV8_ENABLE_DCACHE. */
+#if V8_ENABLE_ICACHE
+    SCB_EnableICache();
+#endif
+#if V8_ENABLE_DCACHE
+    SCB_EnableDCache();
+#endif
+
+    /* 48 MHz generator for the RNG (V8 has no RNG kernel-clock mux in
+     * CCIPR1..12; the MCG48 block is the source). Enable and wait ready,
+     * bounded, before wolfCrypt touches the RNG. */
+    RCC_S->CR |= RCC_CR_MCG48MCKEN;
+    {
+        uint32_t t0;
+        for (t0 = 0; t0 < 1000000u; t0++) {
+            if ((RCC_S->SR & RCC_SR_MCG48RDY) != 0u) {
+                break;
+            }
+        }
+    }
+
+#ifdef V8_TRY_PLL
+    /* Experimental PLL bring-up (no RM: N6-style +1 encodings assumed).
+     * mcg_48m ref: DIVM=2 (/3 -> 16 MHz), DIVN=61 (x62 -> 992 MHz VCO),
+     * DIVP=1 (/2 -> 496 MHz). Fail-safe: bounded lock wait; on timeout we
+     * stay on MCG at 250 MHz and say so. Run from SRAM so flash wait-states
+     * cannot bite at the higher clock. */
+    {
+        uint32_t i;
+#ifndef V8_PLL_VCORGE
+#define V8_PLL_VCORGE 0u
+#endif
+        RCC_S->PLL1CFGR = (2u << 24) | ((uint32_t)V8_PLL_VCORGE << 20)
+                        | (1u << 16) | (1u << 8); /* M, VCORGE, SRC, PEN */
+#ifndef V8_PLL_DIVN
+#define V8_PLL_DIVN 61u   /* x62: 16 MHz ref -> 992 MHz VCO -> /2 = 496 MHz */
+#endif
+#ifndef V8_PLL_OUT_HZ
+#define V8_PLL_OUT_HZ 496000000u
+#endif
+        RCC_S->PLL1DIVR1 = ((uint32_t)V8_PLL_DIVN << 16);
+#ifndef V8_PLL_DIVP
+#define V8_PLL_DIVP 1u
+#endif
+        RCC_S->PLL1DIVR2 = ((uint32_t)V8_PLL_DIVP << 8) | (1u << 24);
+        RCC_S->CR |= (1u << 24);                       /* PLL1ON */
+        for (i = 0; i < 2000000u; i++) {
+            if ((RCC_S->SR & (1u << 24)) != 0u) {      /* PLL1RDY */
+                break;
+            }
+        }
+        if ((RCC_S->SR & (1u << 24)) != 0u) {
+            RCC_S->CFGR1 = (RCC_S->CFGR1 & ~(3u << 24)) | (2u << 24);
+            for (i = 0; i < 100000u; i++) {
+                if (((RCC_S->CFGR1 >> 28) & 3u) == 2u) {
+                    break;
+                }
+            }
+            v8_pll_hz = (((RCC_S->CFGR1 >> 28) & 3u) == 2u)
+                        ? V8_PLL_OUT_HZ : 0u;
+        }
+        else {
+            v8_pll_hz = 0u;
+        }
+    }
+#endif
+
+    board_common_systick_init(board_sysclk_hz());
+    v8_dump_rcc();
+#ifdef V8_TRY_PLL
+    printf("[pll] %s (SR=%08lx CFGR1=%08lx)\n",
+        (v8_pll_hz != 0u) ? "LOCKED+SWITCHED (PLL)" : "fallback MCG 250 MHz",
+        (unsigned long)RCC_S->SR, (unsigned long)RCC_S->CFGR1);
+#endif
+
+    /* v8 ships no system_stm32v8xx.c, so SystemCoreClock would stay at the
+     * weak 0 fallback. PLL builds take board_sysclk_hz() so a locked PLL is
+     * reflected; the default arm stays a constant store to keep codegen
+     * identical to the hardware-validated build (see the placement note in
+     * board.mk). */
+#ifdef V8_TRY_PLL
+    SystemCoreClock = board_sysclk_hz();
+#else
+    SystemCoreClock = V8_SYSCLK_HZ;
+#endif
+
+}
+
+/* One-shot RCC state dump (raw hex, decode against STM32V873.svd). */
+static void v8_dump_rcc(void)
+{
+    printf("[rcc] CR=%08lx SR=%08lx CFGR1=%08lx CFGR2=%08lx\n",
+        (unsigned long)RCC_S->CR, (unsigned long)RCC_S->SR,
+        (unsigned long)RCC_S->CFGR1, (unsigned long)RCC_S->CFGR2);
+    printf("[rcc] PLL1CFGR=%08lx DIVR1=%08lx DIVR2=%08lx DIVR3=%08lx\n",
+        (unsigned long)RCC_S->PLL1CFGR, (unsigned long)RCC_S->PLL1DIVR1,
+        (unsigned long)RCC_S->PLL1DIVR2, (unsigned long)RCC_S->PLL1DIVR3);
+    printf("[rcc] PLL2CFGR=%08lx P2DIVR1=%08lx\n",
+        (unsigned long)RCC_S->PLL2CFGR, (unsigned long)RCC_S->PLL2DIVR1);
+}
+
+uint32_t board_sysclk_hz(void)
+{
+#ifdef V8_TRY_PLL
+    if (v8_pll_hz != 0u) {
+        return v8_pll_hz;
+    }
+#endif
+    return V8_SYSCLK_HZ;
+}
+
+const char *board_name(void)
+{
+    return "NUCLEO-V873XJ (STM32V873XJ Cortex-M85)";
+}

--- a/STM32_Bare_Test/boards/v8/startup_stm32v873xx.c
+++ b/STM32_Bare_Test/boards/v8/startup_stm32v873xx.c
@@ -1,0 +1,95 @@
+/* startup_stm32v873xx.c - minimal C startup for NUCLEO-V873XJ (Cortex-M85)
+ *
+ * Copyright (C) 2026 wolfSSL Inc.
+ *
+ * Linked and run in Secure state: the part has no TZEN option byte, both
+ * flash-bank watermarks are secure and BOOTADD is 0x18000000. Only SysTick
+ * is wired; other interrupts land in Default_Handler.
+ */
+
+#include "stm32v8xx.h"
+
+extern uint32_t __StackTop;
+extern uint32_t __StackLimit;
+/* __copy_table_* / __zero_table_* are declared by CMSIS (cmsis_gcc_m.h) as
+ * const __copy_table_t / __zero_table_t; re-declaring them as uint32_t here
+ * is a type-qualifier conflict, so use the CMSIS types directly. */
+
+extern int  main(void);
+/* CMSIS __cmsis_start: processes the linker's copy/zero tables then enters
+ * the program. It declares __copy_table_t / __zero_table_t and the
+ * __copy_table_* / __zero_table_* symbols in its own scope, so do not
+ * re-declare them here. */
+extern __NO_RETURN void __PROGRAM_START(void);
+
+void Reset_Handler(void);
+void Default_Handler(void);
+
+/* Core exceptions: weak so a board/test file can override any of them. */
+void NMI_Handler(void)        __attribute__((weak, alias("Default_Handler")));
+void HardFault_Handler(void)  __attribute__((weak, alias("Default_Handler")));
+void MemManage_Handler(void)  __attribute__((weak, alias("Default_Handler")));
+void BusFault_Handler(void)   __attribute__((weak, alias("Default_Handler")));
+void UsageFault_Handler(void) __attribute__((weak, alias("Default_Handler")));
+void SecureFault_Handler(void)__attribute__((weak, alias("Default_Handler")));
+void SVC_Handler(void)        __attribute__((weak, alias("Default_Handler")));
+void DebugMon_Handler(void)   __attribute__((weak, alias("Default_Handler")));
+void PendSV_Handler(void)     __attribute__((weak, alias("Default_Handler")));
+void SysTick_Handler(void)    __attribute__((weak, alias("Default_Handler")));
+
+/* 16 core entries + room for every device IRQ in STM32V873.svd. */
+#define V8_NUM_DEVICE_IRQ 240
+
+typedef void (*vector_t)(void);
+
+const vector_t __vectors[16 + V8_NUM_DEVICE_IRQ]
+    __attribute__((section(".vectors"), used)) = {
+    (vector_t)(&__StackTop),
+    Reset_Handler,
+    NMI_Handler,
+    HardFault_Handler,
+    MemManage_Handler,
+    BusFault_Handler,
+    UsageFault_Handler,
+    SecureFault_Handler,
+    0, 0, 0,
+    SVC_Handler,
+    DebugMon_Handler,
+    0,
+    PendSV_Handler,
+    SysTick_Handler,
+    /* Rest default to 0; the NVIC is never enabled for them, so a stray
+     * interrupt traps in HardFault rather than branching wild. */
+};
+
+void Default_Handler(void)
+{
+    while (1) {
+        /* spin - attach a debugger and read the stacked PC */
+    }
+}
+
+/* Naked: a jump-started entry (SRAM load via debugger, no vector fetch)
+ * arrives with garbage SP, so not even a prologue push is safe until MSP
+ * is ours. Set stack in asm, then continue in C. */
+__attribute__((naked)) void Reset_Handler(void)
+{
+    __asm volatile(
+        "movs r0, #0            \n"
+        "msr  msplim, r0        \n"
+        "ldr  r0, =__StackTop   \n"
+        "msr  msp, r0           \n"
+        "ldr  r0, =__StackLimit \n"
+        "msr  msplim, r0        \n"
+        "b    Reset_Continue    \n");
+}
+
+__attribute__((used)) void Reset_Continue(void)
+{
+    SCB->VTOR = (uint32_t)&__vectors[0];
+    __DSB();
+    __ISB();
+
+    /* Copies .data, zeroes .bss, then enters the program. */
+    __PROGRAM_START();
+}

--- a/STM32_Bare_Test/boards/v8/stm32v873_flat.ld
+++ b/STM32_Bare_Test/boards/v8/stm32v873_flat.ld
@@ -1,0 +1,196 @@
+/* STM32V873XJ (NUCLEO-V873XJ) flat linker script - STM32_Bare_Test.
+ *
+ * The part has no TZEN option byte and always runs Secure, so this links
+ * against the secure aliases: flash 0x18000000 (4 MB), AXI SRAM 0x34000000.
+ * RAM is ST's official map: 1216K at 0x34030000 (the low 192K of the AXI
+ * range is the TCM-share pool, not plain SRAM).
+ */
+
+ENTRY(Reset_Handler)
+
+HEAP_SIZE  = 0x60000;   /* 384K heap  - ML-DSA/ML-KEM key material */
+STACK_SIZE = 0x40000;   /* 256K stack - SP-math ECC and ML-DSA sign frames */
+
+/* Aliases for the STM32_Bare_Test STACK=1 adapter -- see board_common.c. */
+_Min_Heap_Size  = HEAP_SIZE;
+_Min_Stack_Size = STACK_SIZE;
+
+MEMORY
+{
+  ROM (rx)  : org = 0x18000000, len = 0x400000
+  /* ST's official linker script (CubeIDE project) places RAM at 0x34030000
+   * with 1216K total; the low 192K below it is NOT ordinary AXI SRAM. With
+   * data/heap in the low region, wolfcrypt_test stalled at layout-sensitive
+   * points (moved when printfs were added); adopting ST's map is the fix
+   * under test. */
+  RAM (xrw) : org = 0x34030000, len = 0x130000
+}
+
+SECTIONS
+{
+  .vectors :
+  {
+    . = ALIGN(8);
+    KEEP(*(.vectors));
+    . = ALIGN(8);
+  } > ROM
+
+  .text :
+  {
+    . = ALIGN(8);
+    *(.text);
+    *(.text*);
+    *(.glue_7);
+    *(.glue_7t);
+    *(.eh_frame);
+    KEEP (*(.init));
+    KEEP (*(.fini));
+    . = ALIGN(8);
+    _etext = .;
+  } > ROM
+
+  .rodata :
+  {
+    . = ALIGN(8);
+    *(.rodata);
+    *(.rodata*);
+    . = ALIGN(8);
+  } > ROM
+
+  .ARM.extab (READONLY) :
+  {
+    . = ALIGN(8);
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+    . = ALIGN(8);
+  } > ROM
+
+  .ARM (READONLY) :
+  {
+    . = ALIGN(8);
+    __exidx_start = .;
+    *(.ARM.exidx*);
+    __exidx_end = .;
+    . = ALIGN(8);
+  } > ROM
+
+  .preinit_array (READONLY) :
+  {
+    . = ALIGN(8);
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP (*(.preinit_array*));
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+    . = ALIGN(8);
+  } > ROM
+
+  .init_array (READONLY) :
+  {
+    . = ALIGN(8);
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP (*(SORT(.init_array.*)));
+    KEEP (*(.init_array*));
+    PROVIDE_HIDDEN (__init_array_end = .);
+    . = ALIGN(8);
+  } > ROM
+
+  .fini_array (READONLY) :
+  {
+    . = ALIGN(8);
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP (*(SORT(.fini_array.*)));
+    KEEP (*(.fini_array*));
+    PROVIDE_HIDDEN (__fini_array_end = .);
+    . = ALIGN(8);
+  } > ROM
+
+  .copy.table (READONLY) :
+  {
+    . = ALIGN(8);
+    __copy_table_start__ = .;
+    LONG (LOADADDR(.data));
+    LONG (ADDR(.data));
+    LONG (SIZEOF(.data) / 4);
+    __copy_table_end__ = .;
+  } > ROM
+
+  .zero.table (READONLY) :
+  {
+    . = ALIGN(8);
+    __zero_table_start__ = .;
+    LONG (ADDR(.bss));
+    LONG (SIZEOF(.bss) / 4);
+    __zero_table_end__ = .;
+  } > ROM
+
+  .data :
+  {
+    . = ALIGN(8);
+    _sidata = LOADADDR(.data);
+    __data_start__ = .;
+    _sdata = .;
+    *(.data);
+    *(.data*);
+    . = ALIGN(8);
+    _edata = .;
+  } > RAM AT> ROM
+
+  .bss :
+  {
+    . = ALIGN(8);
+    _sbss = .;
+    __bss_start__ = _sbss;
+    *(.bss);
+    *(.bss*);
+    *(COMMON);
+    . = ALIGN(8);
+    _ebss = .;
+    __bss_end__ = _ebss;
+  } > RAM
+
+  /* Survives reset: NOT listed in .zero.table, so __PROGRAM_START leaves it
+   * alone. The SWD console log lives here, which lets a completed (or hung)
+   * run be read back after a mode=UR connect -- reset does not clear SRAM. */
+  .noinit (NOLOAD) :
+  {
+    . = ALIGN(8);
+    *(.noinit)
+    *(.noinit*)
+    . = ALIGN(8);
+  } > RAM
+
+  .heap (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE (end = .);
+    PROVIDE (_end = .);
+    _heap_start = .;
+    . += HEAP_SIZE;
+    . = ALIGN(8);
+    _heap_end = .;
+    PROVIDE (_heap_limit = .);
+    __HeapLimit = .;
+  } > RAM
+
+  .stack (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . += STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+    _estack = .;
+    __stack = .;
+  } > RAM
+
+  /DISCARD/ :
+  {
+    libc.a ( * )
+    libm.a ( * )
+    libgcc.a ( * )
+  }
+
+  .ARM.attributes 0 :
+  {
+    *(.ARM.attributes)
+  }
+}

--- a/STM32_Bare_Test/boards/v8/stm32v873_lrun.ld
+++ b/STM32_Bare_Test/boards/v8/stm32v873_lrun.ld
@@ -1,0 +1,199 @@
+/* STM32V873XJ SRAM-execution linker script - STM32_Bare_Test.
+ *
+ * Everything (vectors, code, data) lives in AXI SRAM; nothing touches
+ * flash at runtime. Purpose: the freeze-discriminator experiment -- if the
+ * placement-sensitive wolfcrypt_test freeze never occurs when executing
+ * from SRAM, the flash fetch path is implicated. Load with CubeProgrammer
+ * (-w app.elf) and start at the Reset_Handler entry; the startup sets its
+ * own MSP/MSPLIM so no vector-table SP fetch is needed.
+ *
+ * SRAM per ST's map: 0x34030000 + 1216K. Code 512K + data 704K.
+ */
+ENTRY(Reset_Handler)
+
+HEAP_SIZE  = 0x60000;   /* 384K heap  - ML-DSA/ML-KEM key material */
+STACK_SIZE = 0x40000;   /* 256K stack - SP-math ECC and ML-DSA sign frames */
+
+/* Aliases for the STM32_Bare_Test STACK=1 adapter -- see board_common.c. */
+_Min_Heap_Size  = HEAP_SIZE;
+_Min_Stack_Size = STACK_SIZE;
+
+MEMORY
+{
+  ROM (rx)  : org = 0x34030000, len = 0x80000
+  /* ST's official linker script (CubeIDE project) places RAM at 0x34030000
+   * with 1216K total; the low 192K below it is NOT ordinary AXI SRAM. With
+   * data/heap in the low region, wolfcrypt_test stalled at layout-sensitive
+   * points (moved when printfs were added); adopting ST's map is the fix
+   * under test. */
+  RAM (xrw) : org = 0x340B0000, len = 0xB0000
+}
+
+SECTIONS
+{
+  .vectors :
+  {
+    . = ALIGN(8);
+    KEEP(*(.vectors));
+    . = ALIGN(8);
+  } > ROM
+
+  .text :
+  {
+    . = ALIGN(8);
+    *(.text);
+    *(.text*);
+    *(.glue_7);
+    *(.glue_7t);
+    *(.eh_frame);
+    KEEP (*(.init));
+    KEEP (*(.fini));
+    . = ALIGN(8);
+    _etext = .;
+  } > ROM
+
+  .rodata :
+  {
+    . = ALIGN(8);
+    *(.rodata);
+    *(.rodata*);
+    . = ALIGN(8);
+  } > ROM
+
+  .ARM.extab (READONLY) :
+  {
+    . = ALIGN(8);
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+    . = ALIGN(8);
+  } > ROM
+
+  .ARM (READONLY) :
+  {
+    . = ALIGN(8);
+    __exidx_start = .;
+    *(.ARM.exidx*);
+    __exidx_end = .;
+    . = ALIGN(8);
+  } > ROM
+
+  .preinit_array (READONLY) :
+  {
+    . = ALIGN(8);
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP (*(.preinit_array*));
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+    . = ALIGN(8);
+  } > ROM
+
+  .init_array (READONLY) :
+  {
+    . = ALIGN(8);
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP (*(SORT(.init_array.*)));
+    KEEP (*(.init_array*));
+    PROVIDE_HIDDEN (__init_array_end = .);
+    . = ALIGN(8);
+  } > ROM
+
+  .fini_array (READONLY) :
+  {
+    . = ALIGN(8);
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP (*(SORT(.fini_array.*)));
+    KEEP (*(.fini_array*));
+    PROVIDE_HIDDEN (__fini_array_end = .);
+    . = ALIGN(8);
+  } > ROM
+
+  .copy.table (READONLY) :
+  {
+    . = ALIGN(8);
+    __copy_table_start__ = .;
+    LONG (LOADADDR(.data));
+    LONG (ADDR(.data));
+    LONG (SIZEOF(.data) / 4);
+    __copy_table_end__ = .;
+  } > ROM
+
+  .zero.table (READONLY) :
+  {
+    . = ALIGN(8);
+    __zero_table_start__ = .;
+    LONG (ADDR(.bss));
+    LONG (SIZEOF(.bss) / 4);
+    __zero_table_end__ = .;
+  } > ROM
+
+  .data :
+  {
+    . = ALIGN(8);
+    _sidata = LOADADDR(.data);
+    __data_start__ = .;
+    _sdata = .;
+    *(.data);
+    *(.data*);
+    . = ALIGN(8);
+    _edata = .;
+  } > RAM AT> ROM
+
+  .bss :
+  {
+    . = ALIGN(8);
+    _sbss = .;
+    __bss_start__ = _sbss;
+    *(.bss);
+    *(.bss*);
+    *(COMMON);
+    . = ALIGN(8);
+    _ebss = .;
+    __bss_end__ = _ebss;
+  } > RAM
+
+  /* Survives reset: NOT listed in .zero.table, so __PROGRAM_START leaves it
+   * alone. The SWD console log lives here, which lets a completed (or hung)
+   * run be read back after a mode=UR connect -- reset does not clear SRAM. */
+  .noinit (NOLOAD) :
+  {
+    . = ALIGN(8);
+    *(.noinit)
+    *(.noinit*)
+    . = ALIGN(8);
+  } > RAM
+
+  .heap (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE (end = .);
+    PROVIDE (_end = .);
+    _heap_start = .;
+    . += HEAP_SIZE;
+    . = ALIGN(8);
+    _heap_end = .;
+    PROVIDE (_heap_limit = .);
+    __HeapLimit = .;
+  } > RAM
+
+  .stack (NOLOAD) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . += STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+    _estack = .;
+    __stack = .;
+  } > RAM
+
+  /DISCARD/ :
+  {
+    libc.a ( * )
+    libm.a ( * )
+    libgcc.a ( * )
+  }
+
+  .ARM.attributes 0 :
+  {
+    *(.ARM.attributes)
+  }
+}

--- a/STM32_Bare_Test/boards/v8/tools/svd2cmsis.py
+++ b/STM32_Bare_Test/boards/v8/tools/svd2cmsis.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""Generate a minimal CMSIS device header from a CMSIS-SVD file.
+
+Written for the STM32V8 (NUCLEO-V873XJ) bring-up, where ST publishes no
+device family pack: STM32CubeProgrammer 2.22.0 ships a complete
+SVD/STM32V873.svd, and that file is what a CMSIS header is generated from.
+
+The OUTPUT of this script is derived from ST's SVD and is deliberately NOT
+checked in -- generate it locally, the same way boards/c5a3 points at a
+CubeIDE workspace DFP rather than vendoring one.
+
+Only the peripherals a bare-metal wolfCrypt build touches are emitted, which
+keeps the result reviewable. Add to PERIPHERALS below as needed.
+
+Usage:
+  ./svd2cmsis.py --svd <path to STM32V873.svd> --out <dir> [--all]
+
+Produces <dir>/stm32v8xx.h (and a stm32v873xx.h alias) for use as
+STM32V8_DFP=<dir>/.. -- see boards/v8/board.mk.
+"""
+
+import argparse
+import os
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+# Peripherals needed by wolfCrypt's STM32 BARE path plus board bring-up.
+PERIPHERALS = [
+    'RCC', 'PWR', 'FLASH',
+    'HASH', 'CRYP', 'SAES', 'PKA', 'RNG', 'CCB',
+    'GPIOA', 'GPIOB', 'GPIOC', 'GPIOD', 'GPIOE', 'GPIOF', 'GPIOG',
+    'GPIOH', 'GPIOI', 'GPIOJ', 'GPIOK', 'GPIOM',
+    'USART1', 'USART2', 'USART3', 'USART6', 'USART10',
+    'UART4', 'UART5', 'UART7', 'UART8', 'UART9', 'LPUART1',
+]
+
+
+
+# V2 PKA operand RAM word-offsets. These are properties of the PKA IP
+# firmware, not register fields, so they do not appear in the SVD; the
+# values are byte-identical across every V2 part checked (STM32N6, STM32U5).
+# Word index = (byte_offset - 0x400) >> 2, matching ST's convention.
+PKA_V2_RAM_OFFSETS = [
+    ('PKA_ECC_SCALAR_MUL_IN_A_COEFF', 0x0418),
+    ('PKA_ECC_SCALAR_MUL_IN_A_COEFF_SIGN', 0x0410),
+    ('PKA_ECC_SCALAR_MUL_IN_B_COEFF', 0x0520),
+    ('PKA_ECC_SCALAR_MUL_IN_EXP_NB_BITS', 0x0400),
+    ('PKA_ECC_SCALAR_MUL_IN_INITIAL_POINT_X', 0x0578),
+    ('PKA_ECC_SCALAR_MUL_IN_INITIAL_POINT_Y', 0x0470),
+    ('PKA_ECC_SCALAR_MUL_IN_K', 0x12A0),
+    ('PKA_ECC_SCALAR_MUL_IN_MOD_GF', 0x1088),
+    ('PKA_ECC_SCALAR_MUL_IN_N_PRIME_ORDER', 0x0F88),
+    ('PKA_ECC_SCALAR_MUL_IN_OP_NB_BITS', 0x0408),
+    ('PKA_ECC_SCALAR_MUL_OUT_RESULT_X', 0x0578),
+    ('PKA_ECC_SCALAR_MUL_OUT_RESULT_Y', 0x05D0),
+    ('PKA_ECDSA_SIGN_IN_A_COEFF', 0x0418),
+    ('PKA_ECDSA_SIGN_IN_A_COEFF_SIGN', 0x0410),
+    ('PKA_ECDSA_SIGN_IN_B_COEFF', 0x0520),
+    ('PKA_ECDSA_SIGN_IN_HASH_E', 0x0FE8),
+    ('PKA_ECDSA_SIGN_IN_INITIAL_POINT_X', 0x0578),
+    ('PKA_ECDSA_SIGN_IN_INITIAL_POINT_Y', 0x0470),
+    ('PKA_ECDSA_SIGN_IN_K', 0x12A0),
+    ('PKA_ECDSA_SIGN_IN_MOD_GF', 0x1088),
+    ('PKA_ECDSA_SIGN_IN_MOD_NB_BITS', 0x0408),
+    ('PKA_ECDSA_SIGN_IN_ORDER_N', 0x0F88),
+    ('PKA_ECDSA_SIGN_IN_ORDER_NB_BITS', 0x0400),
+    ('PKA_ECDSA_SIGN_IN_PRIVATE_KEY_D', 0x0F28),
+    ('PKA_ECDSA_SIGN_OUT_ERROR', 0x0FE0),
+    ('PKA_ECDSA_SIGN_OUT_FINAL_POINT_X', 0x1400),
+    ('PKA_ECDSA_SIGN_OUT_FINAL_POINT_Y', 0x1458),
+    ('PKA_ECDSA_SIGN_OUT_SIGNATURE_R', 0x0730),
+    ('PKA_ECDSA_SIGN_OUT_SIGNATURE_S', 0x0788),
+    ('PKA_ECDSA_VERIF_IN_A_COEFF', 0x0470),
+    ('PKA_ECDSA_VERIF_IN_A_COEFF_SIGN', 0x0468),
+    ('PKA_ECDSA_VERIF_IN_HASH_E', 0x13A8),
+    ('PKA_ECDSA_VERIF_IN_INITIAL_POINT_X', 0x0678),
+    ('PKA_ECDSA_VERIF_IN_INITIAL_POINT_Y', 0x06D0),
+    ('PKA_ECDSA_VERIF_IN_MOD_GF', 0x04D0),
+    ('PKA_ECDSA_VERIF_IN_MOD_NB_BITS', 0x04C8),
+    ('PKA_ECDSA_VERIF_IN_ORDER_N', 0x1088),
+    ('PKA_ECDSA_VERIF_IN_ORDER_NB_BITS', 0x0408),
+    ('PKA_ECDSA_VERIF_IN_PUBLIC_KEY_POINT_X', 0x12F8),
+    ('PKA_ECDSA_VERIF_IN_PUBLIC_KEY_POINT_Y', 0x1350),
+    ('PKA_ECDSA_VERIF_IN_SIGNATURE_R', 0x10E0),
+    ('PKA_ECDSA_VERIF_IN_SIGNATURE_S', 0x0C68),
+    ('PKA_ECDSA_VERIF_OUT_RESULT', 0x05D0),
+]
+
+
+def text(node, tag, default=None):
+    if node is None:
+        return default
+    v = node.findtext(tag)
+    return v if v is not None else default
+
+
+def num(s, default=0):
+    if s is None:
+        return default
+    s = s.strip()
+    try:
+        return int(s, 0)
+    except ValueError:
+        return default
+
+
+def resolve(root):
+    """Return {name: (element, base, derived_source_element)}."""
+    by_name = {}
+    for p in root.iter('peripheral'):
+        by_name[text(p, 'name')] = p
+    out = {}
+    for name, p in by_name.items():
+        src = p
+        df = p.get('derivedFrom')
+        if df and df in by_name:
+            src = by_name[df]
+        out[name] = (p, num(text(p, 'baseAddress')), src)
+    return out
+
+
+def registers(per_el):
+    regs = []
+    for r in per_el.iter('register'):
+        regs.append({
+            'name': text(r, 'name'),
+            'off': num(text(r, 'addressOffset')),
+            'size': num(text(r, 'size'), 32) // 8 or 4,
+            'access': text(r, 'access'),
+            'el': r,
+        })
+    regs.sort(key=lambda x: x['off'])
+    return regs
+
+
+def strip_prefix(regname, pername):
+    """SVD names registers HASH_CR; CMSIS structs call the member CR."""
+    for pre in (pername + '_', pername.rstrip('0123456789') + '_'):
+        if regname.startswith(pre) and len(regname) > len(pre):
+            return regname[len(pre):]
+    return regname
+
+
+def coalesce(regs, pername):
+    """Fold contiguous numbered runs (CSR0..CSR102) into arrays (CSR[103]).
+
+    wolfSSL indexes HASH->CSR[i] / HASH->HR[i], so this is required, not
+    cosmetic.
+    """
+    items = []
+    i = 0
+    named = [(strip_prefix(r['name'], pername), r) for r in regs]
+    while i < len(named):
+        nm, r = named[i]
+        m = re.match(r'^(.*?)(\d+)$', nm)
+        if m:
+            stem, idx = m.group(1), int(m.group(2))
+            j, count, expect_off, expect_idx = i, 0, r['off'], idx
+            while j < len(named):
+                nm2, r2 = named[j]
+                m2 = re.match(r'^(.*?)(\d+)$', nm2)
+                if (not m2 or m2.group(1) != stem
+                        or int(m2.group(2)) != expect_idx
+                        or r2['off'] != expect_off):
+                    break
+                count += 1
+                expect_idx += 1
+                expect_off += r2['size']
+                j += 1
+            # ST convention coalesces only the HASH context/digest banks
+            # (CSR[103], HR[], HRA[]) into arrays; everything else -- SAES
+            # KEYR0..7, SUSPR0..7, CRYP CSGCMCCM0..7R -- stays discrete,
+            # and wolfSSL's drivers index them by those discrete names.
+            if count > 1 and idx == 0 and stem in ('CSR', 'HR', 'HRA'):
+                items.append({'kind': 'array', 'name': stem, 'count': count,
+                              'off': r['off'], 'size': r['size'],
+                              'regs': [x[1] for x in named[i:j]]})
+                i = j
+                continue
+        items.append({'kind': 'reg', 'name': nm, 'off': r['off'],
+                      'size': r['size'], 'reg': r})
+        i += 1
+    return items
+
+
+def ctype(size, access):
+    base = {1: 'uint8_t', 2: 'uint16_t', 4: 'uint32_t'}.get(size, 'uint32_t')
+    if access == 'read-only':
+        return '__IM  ' + base
+    if access == 'write-only':
+        return '__OM  ' + base
+    return '__IOM ' + base
+
+
+def emit_struct(pername, per_el, out):
+    regs = registers(per_el)
+    if not regs:
+        return False
+    items = coalesce(regs, pername)
+    out.append('typedef struct {')
+    cursor = 0
+    pad = 0
+    for it in items:
+        if it['off'] > cursor:
+            gap = it['off'] - cursor
+            out.append('  __IM  uint8_t  RESERVED%d[%d];' % (pad, gap))
+            pad += 1
+            cursor = it['off']
+        elif it['off'] < cursor:
+            # overlapping/aliased register - skip, the first definition wins
+            continue
+        if it['kind'] == 'array':
+            acc = it['regs'][0]['access']
+            out.append('  %s %s[%d];' % (ctype(it['size'], acc), it['name'],
+                                         it['count']))
+            cursor += it['size'] * it['count']
+        else:
+            out.append('  %s %s;' % (ctype(it['size'], it['reg']['access']),
+                                     it['name']))
+            cursor += it['size']
+    if pername == 'PKA':
+        # ST's PKA_TypeDef carries the operand RAM after the registers:
+        # pad to 0x400, then RAM[1334] words (matches N6/U5 headers; the
+        # SVD describes only the registers). The driver indexes PKA->RAM[].
+        if cursor < 0x400:
+            out.append('  __IM  uint8_t  RESERVED%d[%d];' % (pad, 0x400 - cursor))
+            pad += 1
+        out.append('  __IOM uint32_t RAM[1334];')
+    out.append('} %s_TypeDef;' % pername)
+    out.append('')
+    return True
+
+
+def emit_fields(pername, per_el, out):
+    seen = set()
+    for r in per_el.iter('register'):
+        rn = text(r, 'name')
+        for f in r.iter('field'):
+            fn = text(f, 'name')
+            off = num(text(f, 'bitOffset'))
+            width = num(text(f, 'bitWidth'), 1)
+            macro = '%s_%s' % (rn, fn)
+            if macro in seen:
+                continue
+            seen.add(macro)
+            mask = ((1 << width) - 1) << off
+            out.append('#define %s_Pos  (%du)' % (macro, off))
+            out.append('#define %s_Msk  (0x%XUL)' % (macro, mask))
+            out.append('#define %s      %s_Msk' % (macro, macro))
+            if width > 1:
+                # ST convention: each bit of a multi-bit field also gets its
+                # own _n macro (e.g. HASH_CR_ALGO_0..3); consumers such as
+                # wolfSSL build algorithm-select values from these.
+                for bit in range(width):
+                    out.append('#define %s_%d  (0x%XUL)'
+                               % (macro, bit, 1 << (off + bit)))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--svd', required=True)
+    ap.add_argument('--out', required=True)
+    ap.add_argument('--all', action='store_true',
+                    help='emit every peripheral, not just the wolfCrypt set')
+    args = ap.parse_args()
+
+    root = ET.parse(args.svd).getroot()
+    res = resolve(root)
+    device = text(root, 'name', 'STM32V873')
+
+    wanted = sorted(res.keys()) if args.all else PERIPHERALS
+
+    out = []
+    out.append('/* Generated by svd2cmsis.py from %s -- DO NOT EDIT, DO NOT'
+               % os.path.basename(args.svd))
+    out.append(' * CHECK IN. Derived from STMicroelectronics SVD data; keep it')
+    out.append(' * local like a vendor DFP. Regenerate with boards/v8/tools.')
+    out.append(' */')
+    out.append('#ifndef STM32V8XX_H')
+    out.append('#define STM32V8XX_H')
+    out.append('#ifdef __cplusplus')
+    out.append('extern "C" {')
+    out.append('#endif')
+    out.append('')
+    out.append('#include <stdint.h>')
+    out.append('')
+
+    # ---- interrupt numbers ----
+    irqs = {}
+    for p in root.iter('peripheral'):
+        for it in p.iter('interrupt'):
+            irqs.setdefault(num(text(it, 'value')), text(it, 'name'))
+    out.append('typedef enum {')
+    out.append('  NonMaskableInt_IRQn   = -14,')
+    out.append('  HardFault_IRQn        = -13,')
+    out.append('  MemoryManagement_IRQn = -12,')
+    out.append('  BusFault_IRQn         = -11,')
+    out.append('  UsageFault_IRQn       = -10,')
+    out.append('  SecureFault_IRQn      = -9,')
+    out.append('  SVCall_IRQn           = -5,')
+    out.append('  DebugMonitor_IRQn     = -4,')
+    out.append('  PendSV_IRQn           = -2,')
+    out.append('  SysTick_IRQn          = -1,')
+    for v in sorted(irqs):
+        out.append('  %s_IRQn = %d,' % (irqs[v], v))
+    out.append('} IRQn_Type;')
+    out.append('')
+
+    # ---- core configuration (SVD carries no <cpu> element) ----
+    out.append('#define __CM85_REV              0x0001U')
+    out.append('#define __NVIC_PRIO_BITS        4U')
+    out.append('#define __Vendor_SysTickConfig  0U')
+    out.append('#define __FPU_PRESENT           1U')
+    out.append('#define __MPU_PRESENT           1U')
+    out.append('#define __DSP_PRESENT           1U')
+    out.append('#define __ICACHE_PRESENT        1U')
+    out.append('#define __DCACHE_PRESENT        1U')
+    out.append('#define __SAUREGION_PRESENT     1U')
+    out.append('#include "core_cm85.h"')
+    out.append('')
+
+    emitted = []
+    for name in wanted:
+        if name not in res:
+            continue
+        per_el, base, src = res[name]
+        if src is per_el:
+            if emit_struct(name, per_el, out):
+                emitted.append(name)
+        else:
+            emitted.append(name)
+
+    # ---- bases and instances (including _S secure aliases) ----
+    out.append('')
+    for name in sorted(res):
+        stem = name[:-2] if name.endswith('_S') else name
+        if stem not in emitted:
+            continue
+        per_el, base, src = res[name]
+        sname = text(src, 'name')
+        tname = (sname[:-2] if sname.endswith('_S') else sname) + '_TypeDef'
+        out.append('#define %s_BASE (0x%08XUL)' % (name, base))
+        out.append('#define %s ((%s *)%s_BASE)' % (name, tname, name))
+    out.append('')
+
+    # ---- HASH_DIGEST compat instance (ST convention) ----
+    # ST headers expose the extended digest bank (HR0..15 at HASH_BASE+0x310)
+    # as a separate HASH_DIGEST peripheral; wolfSSL keys its whole SHA-2/SHA-3
+    # HASH capability tree on '#ifdef HASH_DIGEST' and reads
+    # HASH_DIGEST->HR[i]. Emit the same shape.
+    if 'HASH' in emitted:
+        out.append('')
+        out.append('typedef struct {')
+        out.append('  __IOM uint32_t HR[16];')
+        out.append('} HASH_DIGEST_TypeDef;')
+        out.append('#define HASH_DIGEST_BASE (%s_BASE + 0x310UL)'
+                   % 'HASH')
+        out.append('#define HASH_DIGEST ((HASH_DIGEST_TypeDef *)HASH_DIGEST_BASE)')
+        out.append('#define HASH_DIGEST_S ((HASH_DIGEST_TypeDef *)(HASH_S_BASE + 0x310UL))')
+
+    # ---- V2 PKA operand RAM offsets (IP constants, not SVD material) ----
+    if 'PKA' in emitted:
+        out.append('')
+        out.append('#define PKA_RAM_OFFSET  (0x0400UL)')
+        for nm, byteoff in PKA_V2_RAM_OFFSETS:
+            out.append('#define %s  ((0x%04XUL - PKA_RAM_OFFSET)>>2)'
+                       % (nm, byteoff))
+
+    # ---- field macros ----
+    for name in emitted:
+        per_el, base, src = res[name]
+        if src is per_el:
+            emit_fields(name, per_el, out)
+    out.append('')
+    out.append('#ifdef __cplusplus')
+    out.append('}')
+    out.append('#endif')
+    out.append('#endif /* STM32V8XX_H */')
+
+    os.makedirs(args.out, exist_ok=True)
+    path = os.path.join(args.out, 'stm32v8xx.h')
+    with open(path, 'w') as fh:
+        fh.write('\n'.join(out) + '\n')
+    alias = os.path.join(args.out, 'stm32v873xx.h')
+    with open(alias, 'w') as fh:
+        fh.write('#include "stm32v8xx.h"\n')
+    sys.stderr.write('wrote %s (%d peripherals, %d interrupts)\n'
+                     % (path, len(emitted), len(irqs)))
+
+
+if __name__ == '__main__':
+    main()

--- a/STM32_Bare_Test/src/main_v8sha3.c
+++ b/STM32_Bare_Test/src/main_v8sha3.c
@@ -1,0 +1,118 @@
+/* main_v8sha3.c - STM32V8 HASH SHA-3/SHAKE silicon probe (no wolfCrypt)
+ *
+ * Copyright (C) 2026 wolfSSL Inc.
+ *
+ * The V8 HASH block advertises six ALGO codes beyond SHA-1/2 (0x4..0x7,
+ * 0x8..0x9), inferred as SHA3-224/256/384/512 + SHAKE128/256 -- the SVD enum
+ * names are placeholders, so this probe settles it against NIST vectors on
+ * silicon. It also answers the question that decides the ML-KEM/ML-DSA
+ * story: can SHAKE resume a squeeze (second DCAL without INIT continuing
+ * the output stream), or is it fixed-length like the STM32MP13?
+ *
+ * Raw hex is printed; verify host-side (python3 hashlib sha3_256/shake_256).
+ */
+
+#include "stm32v8xx.h"
+#include "board.h"
+#include <stdio.h>
+
+#define ALGO_SHIFT      HASH_CR_ALGO_Pos
+#define DATATYPE_8B     (2u << 4)   /* byte-swap input, per wolfSSL usage */
+#define WAIT_LIMIT      1000000u
+
+static int wait_flag(volatile uint32_t *reg, uint32_t mask)
+{
+    uint32_t i;
+    for (i = 0; i < WAIT_LIMIT; i++) {
+        if ((*reg & mask) != 0u) {
+            return 0;
+        }
+    }
+    return -1;
+}
+
+static void dump_hr(const char *tag, unsigned int words)
+{
+    unsigned int i;
+    printf("%s:", tag);
+    for (i = 0; i < words; i++) {
+        printf(" %08lx", (unsigned long)HASH_S->HR[i]);
+    }
+    printf("\n");
+}
+
+/* One fixed-length hash: init with the given ALGO code, absorb len bytes,
+ * finalize, dump 'words' output words. Returns 0 on flag-wait success. */
+static int probe_hash(const char *tag, uint32_t algo, const char *msg,
+    uint32_t len, unsigned int words)
+{
+    uint32_t w;
+    uint32_t i;
+
+    HASH_S->CR = (algo << ALGO_SHIFT) | DATATYPE_8B | HASH_CR_INIT;
+    for (i = 0; i < len; i += 4u) {
+        uint32_t b0 = (uint32_t)(unsigned char)msg[i];
+        uint32_t b1 = (i + 1u < len) ? (uint32_t)(unsigned char)msg[i+1u] : 0u;
+        uint32_t b2 = (i + 2u < len) ? (uint32_t)(unsigned char)msg[i+2u] : 0u;
+        uint32_t b3 = (i + 3u < len) ? (uint32_t)(unsigned char)msg[i+3u] : 0u;
+        w = b0 | (b1 << 8) | (b2 << 16) | (b3 << 24);
+        HASH_S->DIN = w;
+    }
+    HASH_S->STR = (len * 8u) & HASH_STR_NBLW_Msk;
+    HASH_S->STR |= HASH_STR_DCAL;
+    if (wait_flag(&HASH_S->SR, HASH_SR_DCIS) != 0) {
+        printf("%s: TIMEOUT (SR=%08lx)\n", tag, (unsigned long)HASH_S->SR);
+        return -1;
+    }
+    dump_hr(tag, words);
+    return 0;
+}
+
+int main(void)
+{
+    int rc;
+
+    board_init();
+    printf("\n[v8sha3] HASH SHA-3/SHAKE probe\n");
+
+    RCC_S->AHB3ENR |= RCC_AHB3ENR_HASHEN;
+    (void)RCC_S->AHB3ENR;
+
+    /* --- fixed-length SHA-3, ALGO codes 0x4..0x7, vs NIST("abc") --- */
+    probe_hash("sha3_224(abc) a4", 0x4u, "abc", 3u, 7u);
+    probe_hash("sha3_256(abc) a5", 0x5u, "abc", 3u, 8u);
+    probe_hash("sha3_384(abc) a6", 0x6u, "abc", 3u, 12u);
+    probe_hash("sha3_512(abc) a7", 0x7u, "abc", 3u, 16u);
+    /* empty-message corner */
+    probe_hash("sha3_256() a5", 0x5u, "", 0u, 8u);
+
+    /* --- SHAKE, codes 0x8/0x9: first output block --- */
+    probe_hash("shake128(abc) a8", 0x8u, "abc", 3u, 16u);
+    rc = probe_hash("shake256(abc) a9", 0x9u, "abc", 3u, 16u);
+
+    /* --- THE question: does a second DCAL (no INIT) continue the
+     * stream? If HR changes to SHAKE256("abc") bytes 64..127, the
+     * squeeze is resumable and PQC offload is on the table. --- */
+    if (rc == 0) {
+        /* DCIS is sticky from the first finalize; a wait on it now would
+         * return instantly and prove nothing. Try to clear it first (W0C
+         * attempt), and report whether the second wait was genuine. */
+        HASH_S->SR = 0u;
+        if ((HASH_S->SR & HASH_SR_DCIS) != 0u) {
+            printf("squeeze2: DCIS not clearable without INIT "
+                   "(SR=%08lx) -- resume test INCONCLUSIVE by this method\n",
+                (unsigned long)HASH_S->SR);
+        }
+        HASH_S->STR |= HASH_STR_DCAL;
+        if (wait_flag(&HASH_S->SR, HASH_SR_DCIS) == 0) {
+            dump_hr("shake256 squeeze2", 16u);
+        }
+        else {
+            printf("squeeze2: TIMEOUT (SR=%08lx)\n",
+                (unsigned long)HASH_S->SR);
+        }
+    }
+
+    printf("[v8sha3] done\n");
+    while (1) { }
+}

--- a/STM32_Bare_Test/user_settings.h
+++ b/STM32_Bare_Test/user_settings.h
@@ -134,6 +134,45 @@ extern "C" {
     #if defined(BUILD_BARE)
         #define WOLFSSL_STM32_PKA
     #endif
+#elif defined(STM32_BOARD_V8)
+    /* NUCLEO-V873XJ (STM32V873XJ): Cortex-M85, Armv8.1-M + Helium, 4 MB
+     * flash, device ID 0x499 Rev B.
+     *
+     * Inventory read from STM32CubeProgrammer 2.22.0's SVD/STM32V873.svd:
+     * CRYP (fat -- K0LR..K3RR, CSGCMCCM0..7R, GCM_CCMPH, 2-bit KEYSIZE, so
+     * AES-192 IS supported), SAES (DHUK/BHK via CR.KEYSEL), HASH (new-gen,
+     * CSR0..102 -> HASH_CR_SIZE 103, HR0..15 -> 64-byte digest), PKA (V2
+     * with BOTH sign 0x24 and verify 0x26 -- not restricted like C5/H563),
+     * RNG (CONDRST/NISTC/HTCR0..3) and CCB. All six clocks live on
+     * RCC_AHB3ENR bits 0/1/2/3/8/15. That topology matches N6, so the
+     * wolfSSL stm32.h arms should be cloned from N6, not from C5.
+     *
+     * HASH_CR.ALGO is 4 bits with 13 values. Seven -- 0x0/0x2/0x3/0xC/0xD/
+     * 0xE/0xF -- match wolfSSL's existing new-gen SHA-1/2 mapping exactly.
+     * The six extras (0x4-0x7, 0x8-0x9) are almost certainly SHA3-224/256/
+     * 384/512 + SHAKE128/256, but the SVD enum names are placeholders so
+     * that assignment is INFERRED, not documented -- confirm against the RM
+     * or an on-silicon KAT before relying on it. Note there is no SHA3CFGR
+     * register and the digest stops at 64 bytes, which strongly suggests a
+     * fixed-length (non-resumable) XOF squeeze -- i.e. no ML-KEM/ML-DSA win.
+     *
+     * HW blocks are enabled one at a time as each is validated on this
+     * silicon. */
+    #define WOLFSSL_STM32V8
+    /* Umbrella derives STM32_RNG/HASH/CRYPTO/HMAC; opt out of what is not
+     * validated yet. RNG's MCG48 source is enabled in hw_init.c (V8 has no
+     * CCIPR mux for it). */
+    /* AES enabled 8/26, routed through the SAES instance like N6: the BARE
+     * TinyAES driver shape matches SAES registers (IVR0..3, KEYR0..7); the
+     * fat CRYP (IV0LR.., K0LR..) would need its own bare path wiring. Costs
+     * AES-192 (settings.h gates NO_AES_192 on USE_SAES for V8, as for N6). */
+    #define WOLFSSL_STM32_USE_SAES
+    /* V2 PKA (sign AND verify, per PKA_CR.MODE enum). Operand RAM offsets
+     * are IP constants emitted by svd2cmsis.py. BARE only, as on N657. */
+    #if defined(BUILD_BARE)
+        #define WOLFSSL_STM32_PKA
+    #endif
+    #define NO_STM32_HMAC  /* match C5A3/C562 until HKDF-over-HW is proven */
 #elif defined(STM32_BOARD_C562)
     #define WOLFSSL_STM32C5
     /* NUCLEO-C562RE: same C5 family as C5A3. Same crypto IP set: AES
@@ -397,7 +436,7 @@ extern "C" {
     #define STM32_C031_TRIM
     #define WOLFSSL_SMALL_STACK
 #else
-    #error "Define one of STM32_BOARD_C031 / STM32_BOARD_H5 / STM32_BOARD_H573 / STM32_BOARD_H7 / STM32_BOARD_H723 / STM32_BOARD_H7A3 / STM32_BOARD_H7S3 / STM32_BOARD_U5 / STM32_BOARD_U3 / STM32_BOARD_U585 / STM32_BOARD_U545 / STM32_BOARD_U083 / STM32_BOARD_C562 / STM32_BOARD_C5A3 / STM32_BOARD_WB55 / STM32_BOARD_WL55 / STM32_BOARD_G071 / STM32_BOARD_G474 / STM32_BOARD_G491 / STM32_BOARD_WBA52 / STM32_BOARD_F207 / STM32_BOARD_F303 / STM32_BOARD_F437 / STM32_BOARD_F439 / STM32_BOARD_F767 / STM32_BOARD_L4A6 / STM32_BOARD_L552 / STM32_BOARD_L562"
+    #error "Define one of STM32_BOARD_C031 / STM32_BOARD_H5 / STM32_BOARD_H573 / STM32_BOARD_H7 / STM32_BOARD_H723 / STM32_BOARD_H7A3 / STM32_BOARD_H7S3 / STM32_BOARD_U5 / STM32_BOARD_U3 / STM32_BOARD_U585 / STM32_BOARD_U545 / STM32_BOARD_U083 / STM32_BOARD_C562 / STM32_BOARD_C5A3 / STM32_BOARD_WB55 / STM32_BOARD_WL55 / STM32_BOARD_G071 / STM32_BOARD_G474 / STM32_BOARD_G491 / STM32_BOARD_WBA52 / STM32_BOARD_F207 / STM32_BOARD_F303 / STM32_BOARD_F437 / STM32_BOARD_F439 / STM32_BOARD_F767 / STM32_BOARD_L4A6 / STM32_BOARD_L552 / STM32_BOARD_L562 / STM32_BOARD_V8"
 #endif
 
 /* ---------------------------------------------------------------------- */
@@ -559,7 +598,9 @@ extern "C" {
     #define WOLFSSL_SHA3
     #define WOLFSSL_SHAKE128
     #define WOLFSSL_SHAKE256
-    #define WC_SHA3_NO_ASM
+    #ifndef STM32_BARE_SHA3_ASM
+        #define WC_SHA3_NO_ASM
+    #endif
 
     #define BUILD_CONFIG_NAME "asm"
 #elif defined(BUILD_C)
@@ -607,7 +648,8 @@ extern "C" {
     #endif
     /* asm path scopes WOLFSSL_ARMASM off for sha3.c (thumb2-sha3 ASM
      * is not pulled in -- see wl55 flash-overflow note in Makefile). */
-    #if defined(BUILD_ASM) && !defined(WC_SHA3_NO_ASM)
+    #if defined(BUILD_ASM) && !defined(STM32_BARE_SHA3_ASM) && \
+        !defined(WC_SHA3_NO_ASM)
         #define WC_SHA3_NO_ASM
     #endif
 #endif


### PR DESCRIPTION
Adds `BOARD=v8` for ST's STM32V8 family. STM32V873XJ, Cortex-M85, 4 MB flash, device ID `0x499` Rev B.
Requires: https://github.com/wolfSSL/wolfssl/pull/11296

**What it adds**
- `boards/v8/board.mk`, `startup_stm32v873xx.c`, `hw_init.c`, `stm32v873_flat.ld` - board definition, C startup, bring-up and linker script
- `boards/v8/tools/svd2cmsis.py` - generates the CMSIS device header from ST's SVD
- `boards/common/board-derive.mk` - `m85` and `m85_mve` core profiles
- `boards/common/board_common.c` - `stm32v8xx.h` include arm
- `Makefile`, `user_settings.h`, `bench_matrix.sh`, `README.md` - board registration

**Design notes**
- The part has no TZEN option byte. `SECWM1` and `SECWM2` cover both full flash banks and `BOOTADD` is `0x18000000`, so it always runs Secure. Images link at the secure aliases: flash `0x18000000`, AXI SRAM `0x34000000`, peripherals plus `0x10000000`. A CMSIS header built without `-mcmse` resolves the plain names to the non-secure aliases, which RIFSC blocks.
- `Reset_Handler` clears `MSPLIM` before use. The OEM-iRoT boot ROM can hand off with the Armv8-M stack limit set into its own region, and a push below it escalates to lockup in Secure state. The N657 recipe in the Makefile zeroes `msplim_s` and `psplim_s` for the same reason.
- ST publishes no `stm32v8xx_dfp`, so the CMSIS header is generated locally from the SVD that ships with STM32CubeProgrammer 2.22.0. The generated header is ST derived and is deliberately not checked in. Only the generator is. `board.mk` fails fast with the regeneration command if the header is absent.
- The VCP USART is not identified yet, so `board_putc()` writes a `.noinit` RAM ring buffer that the host reads over SWD.
- `CPU_FREQ_BOOST` is disabled in the option bytes. Measured core clock as shipped is 250 MHz, not the part's 800 MHz rate.

**Building**

```sh
./boards/v8/tools/svd2cmsis.py \
    --svd ~/STMicroelectronics/STM32Cube/STM32CubeProgrammer/SVD/STM32V873.svd \
    --out ~/Projects/STM/STM32V8/stm32v8xx_dfp/Include

make BOARD=v8 CONFIG=c TARGET=test  flash
make BOARD=v8 CONFIG=c TARGET=bench flash

arm-none-eabi-nm build/v8-bare-test-c/app.elf | grep v8_console
STM32_Programmer_CLI -c port=swd sn=<SN> mode=UR -r32 <addr> <bytes>
```

Three things that cost time otherwise. CubeProgrammer 2.22.0 or newer is required, older builds report `Cannot identify the device` for `0x499`. `mode=UR` is required and resets the part, so poll sparingly and check the `boots` counter before trusting a byte count. `-r32` takes a size in bytes, not words, and `v8_console` moves between build targets.

## Hardware / test status

Hardware-validated on NUCLEO-V873XJ. The benchmark target completes with `Benchmark result: 0 (PASS)` across 60 algorithms. Early figures, `CONFIG=c` software crypto, 250 MHz, I-cache on:

| Algorithm | Rate |
|---|---|
| POLY1305 | 10.02 MiB/s |
| MD5 | 7.06 MiB/s |
| SHA-256 | 2.75 MiB/s |
| ChaCha20 | 2.27 MiB/s |
| SHA-512 | 945.3 KiB/s |
| AES-128-CBC encrypt | 900.0 KiB/s |
| AES-128-GCM encrypt | 542.4 KiB/s |
| Ed25519 sign | 10.7 ms |
| X25519 agree | 25.2 ms |
| ECDSA P-256 sign | 122.5 ms |
| ECDSA P-256 verify | 222.2 ms |

The 250 MHz figure is measured, not read from RCC. The PLL is not configured here and no reference manual is public, so it was calibrated against host wall clock. `benchmark.c` times with SysTick, so a wrong `V8_SYSCLK_HZ` silently scales every rate.

I-cache is on by default and worth 1.4x to 2.7x measured on this board (SHA-256 1.11 to 2.75 MiB/s, ECDSA P-256 sign 324.8 to 122.5 ms). D-cache is off: the enable call returns and `board_init()` completes, but the first `printf` then emits nothing, and explicit MPU attributes did not help. Both are build overridable.

## Scope

`wolfcrypt_test` currently stops entering ED25519, reproducibly and with no fault line. The benchmark target exercises ED25519 key generation, signing and verification and completes normally, so ED25519 works on this silicon. Ruled out on hardware, each stopping at the same offset: I-cache, the wolfSSL rebase, the SysTick divisor and the MPU regions. Left open.

`bench_matrix.sh` excludes `v8` from the default sweep, the same mechanism `c031` uses. No STM32V8 hardware crypto is driven yet.